### PR TITLE
Design refresh + Copy/PDF/CSV/Print export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ application/logs/*
 !application/logs/index.html
 !application/logs/.htaccess
 /vendor/
+
+.superpowers/

--- a/docs/superpowers/plans/2026-04-17-design-refresh.md
+++ b/docs/superpowers/plans/2026-04-17-design-refresh.md
@@ -1,0 +1,1979 @@
+# AFibRisk Design Refresh — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current Bootstrap/multi-background design with a modern "Dashboard Médico" identity (dark topbar, clinical blue accents, Inter typography, sidebar-based question navigation) and add Copy / PDF / CSV / Print exports on the results page.
+
+**Architecture:** CodeIgniter 3 views + `style.css` rewrite (no framework) + new `export.js` module loaded only on the results page. Controller untouched except for a single line that persists raw inputs in the session so exports can access them. All scores, condicional field logic, and Tippy tooltip infrastructure preserved.
+
+**Tech Stack:** PHP 7+ (CodeIgniter 3), vanilla JS (ES6), CSS custom properties, Inter font (Google Fonts), Tippy.js + Popper (existing), html2pdf.js 0.10.1 (new CDN), no build step.
+
+**Testing note:** This codebase has no automated test harness (no PHPUnit, no Jest). Each task ends with a manual verification step describing what to check in a browser using XAMPP (`http://localhost/afibrisk/plataforma/`). Screenshot evidence is the acceptance criterion.
+
+---
+
+## File Structure
+
+**Modify (rewrite):**
+- `plataforma/application/views/header.php` — chrome, Inter font, Tippy/Popper, no Bootstrap
+- `plataforma/application/views/footer.php` — jQuery + Tippy/Popper only
+- `plataforma/application/views/home.php` — landing
+- `plataforma/application/views/sobre.php` — about
+- `plataforma/application/views/perguntas/home.php` — questions with sidebar nav
+- `plataforma/application/views/resultado/home.php` — results with toolbar + cards + pdf template
+- `plataforma/assets/css/style.css` — full rewrite with design tokens
+
+**Modify (surgical):**
+- `plataforma/application/controllers/Home.php:154` — add one line before `redirect('results')` to persist raw inputs
+
+**Create:**
+- `plataforma/assets/js/export.js` — Copy, CSV, PDF, Print helpers + toast system
+
+---
+
+## Task 1: Controller — persist inputs for exports
+
+**Files:**
+- Modify: `plataforma/application/controllers/Home.php:153-154`
+
+- [ ] **Step 1: Read current code at the injection point**
+
+Run: open `plataforma/application/controllers/Home.php` and confirm line 154 is `redirect('results');` inside `public function todasRespostas()`. The array `$dados` built in lines 51–97 uses the key pattern `pergunta_N`.
+
+- [ ] **Step 2: Add session persistence for raw POST inputs**
+
+Modify `plataforma/application/controllers/Home.php` — replace:
+
+```php
+		//18. ASAS
+		$this->calculaASAS($dados);
+
+		redirect('results');
+	}
+```
+
+with:
+
+```php
+		//18. ASAS
+		$this->calculaASAS($dados);
+
+		// Persist raw inputs for exports (Copy, CSV, PDF) on the results page
+		$this->session->set_userdata('respostas', $this->input->post());
+
+		redirect('results');
+	}
+```
+
+- [ ] **Step 3: Verify manually**
+
+In a terminal: `grep -n "respostas" plataforma/application/controllers/Home.php` — expect one hit showing the new line.
+
+Start XAMPP. Open `http://localhost/afibrisk/plataforma/questions`. Fill a couple of fields and submit. On the results page, open DevTools console and run:
+```js
+fetch('/afibrisk/plataforma/index.php', { credentials: 'include' })
+```
+Not conclusive without PHPSESSID inspection — instead run in the console on results: this step is validated indirectly when Task 8 renders `window.AFIBRISK_INPUTS` and you see the values. For now just confirm the page still loads and results still show.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/application/controllers/Home.php
+git commit -m "Persist raw inputs in session for exports"
+```
+
+---
+
+## Task 2: CSS foundation — design tokens + base styles
+
+**Files:**
+- Modify (rewrite): `plataforma/assets/css/style.css`
+
+- [ ] **Step 1: Back up current style.css reference**
+
+Run: `cp plataforma/assets/css/style.css plataforma/assets/css/style.css.old` (optional, for quick rollback during dev — will be removed before commit).
+
+- [ ] **Step 2: Replace style.css entirely with the foundation**
+
+Overwrite `plataforma/assets/css/style.css` with:
+
+```css
+/* ============================================================================
+   AFibRisk — Design tokens
+   ============================================================================ */
+:root {
+    --color-ink:          #0f172a;
+    --color-ink-2:        #1e293b;
+    --color-muted:        #64748b;
+    --color-border:       #e2e8f0;
+    --color-surface:      #ffffff;
+    --color-surface-alt:  #f8fafc;
+    --color-primary:      #2563eb;
+    --color-primary-dark: #1d4ed8;
+    --color-success:      #16a34a;
+    --color-danger:       #dc2626;
+
+    --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-6: 24px;
+    --space-8: 32px;
+    --space-12: 48px;
+
+    --radius-sm: 6px;
+    --radius:    10px;
+    --radius-lg: 16px;
+
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow:    0 4px 12px rgba(15, 23, 42, 0.08);
+
+    --topbar-h: 56px;
+    --sidebar-w: 260px;
+}
+
+/* ============================================================================
+   Reset + base
+   ============================================================================ */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+    font-family: var(--font-sans);
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--color-ink-2);
+    background: var(--color-surface-alt);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4 { color: var(--color-ink); font-weight: 700; margin: 0 0 var(--space-4); line-height: 1.25; }
+h1 { font-size: 32px; }
+h2 { font-size: 22px; }
+h3 { font-size: 18px; }
+p  { margin: 0 0 var(--space-4); }
+a  { color: var(--color-primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ============================================================================
+   Focus ring — accessibility baseline
+   ============================================================================ */
+:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* ============================================================================
+   Utility
+   ============================================================================ */
+.sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+.container-narrow {
+    max-width: 720px; margin: 0 auto; padding: var(--space-8) var(--space-4);
+}
+
+/* ============================================================================
+   Buttons
+   ============================================================================ */
+.btn {
+    display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2);
+    padding: 10px 18px; border: 1px solid transparent; border-radius: var(--radius-sm);
+    font-family: inherit; font-size: 14px; font-weight: 600;
+    cursor: pointer; text-decoration: none; transition: background 120ms, border-color 120ms;
+    background: transparent; color: var(--color-ink);
+}
+.btn:hover { text-decoration: none; }
+.btn-primary { background: var(--color-primary); color: #fff; }
+.btn-primary:hover { background: var(--color-primary-dark); color: #fff; }
+.btn-secondary { background: var(--color-surface); color: var(--color-ink); border-color: var(--color-border); }
+.btn-secondary:hover { background: var(--color-surface-alt); }
+.btn-ghost { background: transparent; color: var(--color-muted); }
+.btn-ghost:hover { color: var(--color-ink); background: var(--color-surface-alt); }
+.btn[aria-disabled="true"] { opacity: 0.5; pointer-events: none; }
+
+/* ============================================================================
+   Topbar — shared across all pages
+   ============================================================================ */
+.topbar {
+    position: sticky; top: 0; z-index: 20;
+    height: var(--topbar-h);
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 var(--space-4);
+    background: var(--color-ink); color: #e2e8f0;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.topbar .brand { display: inline-flex; align-items: center; gap: var(--space-2); font-weight: 700; color: #fff; font-size: 15px; letter-spacing: 0.01em; text-decoration: none; }
+.topbar .brand:hover { text-decoration: none; }
+.topbar .brand::before { content: ""; display: inline-block; width: 10px; height: 10px; border-radius: 50%; background: var(--color-primary); }
+.topbar nav { display: flex; gap: var(--space-2); align-items: center; }
+.topbar nav a { color: #cbd5e1; font-size: 14px; font-weight: 500; padding: 6px 10px; border-radius: var(--radius-sm); }
+.topbar nav a:hover { color: #fff; background: rgba(255,255,255,0.08); text-decoration: none; }
+.topbar .hamburger {
+    display: none; background: none; border: 0; color: #cbd5e1; font-size: 22px; cursor: pointer;
+    padding: 4px 8px; border-radius: var(--radius-sm);
+}
+.topbar .hamburger:hover { background: rgba(255,255,255,0.08); color: #fff; }
+
+/* ============================================================================
+   Forms
+   ============================================================================ */
+label { display: block; font-size: 13px; font-weight: 600; color: var(--color-ink-2); margin-bottom: 6px; }
+input[type="text"], input[type="number"] {
+    display: block; width: 100%; max-width: 220px;
+    padding: 8px 10px; font-family: inherit; font-size: 14px;
+    color: var(--color-ink); background: var(--color-surface);
+    border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+    outline: none; transition: border-color 120ms, box-shadow 120ms;
+}
+input[type="text"]:focus, input[type="number"]:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+/* Pill radios: Yes/No, alcohol, etc. */
+.pill-group { display: inline-flex; flex-wrap: wrap; gap: 8px; }
+.pill-group input[type="radio"] { position: absolute; opacity: 0; pointer-events: none; }
+.pill-group label {
+    display: inline-flex; align-items: center;
+    padding: 6px 14px; margin: 0;
+    background: var(--color-surface); color: var(--color-ink-2);
+    border: 1px solid var(--color-border); border-radius: 999px;
+    font-size: 13px; font-weight: 500; cursor: pointer;
+    transition: background 120ms, border-color 120ms, color 120ms;
+}
+.pill-group label:hover { border-color: var(--color-muted); }
+.pill-group input[type="radio"]:checked + label {
+    background: var(--color-primary); color: #fff; border-color: var(--color-primary);
+}
+.pill-group input[type="radio"]:focus-visible + label {
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+/* Field row (label + control inline on desktop) */
+.field { margin-bottom: var(--space-4); }
+.field .hint { font-size: 12px; color: var(--color-muted); margin-top: 4px; }
+.field-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+
+/* ============================================================================
+   Scrollbar (webkit)
+   ============================================================================ */
+::-webkit-scrollbar        { width: 10px; height: 10px; }
+::-webkit-scrollbar-track  { background: var(--color-surface-alt); }
+::-webkit-scrollbar-thumb  { background: #cbd5e1; border-radius: 999px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-muted); }
+
+/* ============================================================================
+   Tippy tooltip theme override — matches new palette
+   ============================================================================ */
+.tippy-box[data-theme='customTooltipCssTema'] {
+    background: #0f172a; color: #f8fafc;
+    border: 1px solid #1e293b; border-radius: var(--radius-sm);
+    font-weight: 500; font-size: 13px; line-height: 1.45;
+    max-width: 420px !important;
+}
+.tippy-box[data-theme='customTooltipCssTema'] .tippy-content { padding: 10px 12px; }
+```
+
+Note: task 2 intentionally stops at this foundation. Page-specific styles (home, sobre, sidebar, results cards, drawer, print) are appended by their own tasks.
+
+- [ ] **Step 3: Verify manually**
+
+Open `http://localhost/afibrisk/plataforma/` — the page will look broken (old views still reference Bootstrap which is being removed in Task 3); that's expected at this stage. Open DevTools Elements tab and confirm the custom properties exist on `:root`. Network tab should still show `style.css` loading (status 200).
+
+If you created the `.old` backup in step 1, delete it now: `rm plataforma/assets/css/style.css.old`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/assets/css/style.css
+git commit -m "Rewrite style.css foundation with design tokens and base styles"
+```
+
+---
+
+## Task 3: Shared chrome — header.php and footer.php
+
+**Files:**
+- Modify (rewrite): `plataforma/application/views/header.php`
+- Modify (rewrite): `plataforma/application/views/footer.php`
+
+- [ ] **Step 1: Rewrite header.php**
+
+Overwrite `plataforma/application/views/header.php` with:
+
+```php
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="AFibRisk — Atrial Fibrillation risk assessment tool">
+
+<title><?php print($titulo); ?></title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" type="text/css" href="<?php echo base_url('assets/css/style.css') ?>">
+
+<script src="<?php echo base_url('assets/js/fontawsome1935e00f36.js') ?>" crossorigin="anonymous"></script>
+```
+
+Key changes from the current header: Bootstrap 5 CSS/JS removed; Multicolore Pro + Roboto Condensed replaced by Inter + JetBrains Mono; FontAwesome kept (used by `.fa-info-circle` on the results page).
+
+- [ ] **Step 2: Rewrite footer.php**
+
+Overwrite `plataforma/application/views/footer.php` with:
+
+```php
+<script src="https://code.jquery.com/jquery-3.6.4.min.js" integrity="sha256-oP6HI9z1XaZNBrJURtCoUT5SUnxFr8s3BzRl+cbzUq8=" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@popperjs/core@2"></script>
+<script src="https://unpkg.com/tippy.js@6"></script>
+```
+
+Key change: jQuery slim (no AJAX/events) swapped for full jQuery 3.6 — Tippy doesn't need jQuery at all, but existing code (`$('.show-reference').click` in the results view) does. Keeping it avoids rewriting that handler.
+
+- [ ] **Step 3: Verify manually**
+
+Refresh `http://localhost/afibrisk/plataforma/`. Open DevTools Network tab — confirm Inter font loads (woff2 requests to fonts.gstatic.com), Tippy loads, Bootstrap does NOT load. Console should have no 404s. The pages will still look unstyled for their bodies (views not yet rewritten) — that's expected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/application/views/header.php plataforma/application/views/footer.php
+git commit -m "Replace Bootstrap with Inter typography in shared chrome"
+```
+
+---
+
+## Task 4: Landing page — home.php
+
+**Files:**
+- Modify (rewrite): `plataforma/application/views/home.php`
+- Modify (append): `plataforma/assets/css/style.css`
+
+- [ ] **Step 1: Append home-specific styles to style.css**
+
+Append to `plataforma/assets/css/style.css`:
+
+```css
+/* ============================================================================
+   Home page
+   ============================================================================ */
+.home-hero {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    min-height: calc(100vh - var(--topbar-h));
+    padding: var(--space-12) var(--space-4);
+    text-align: center;
+}
+.home-hero .eyebrow {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--color-primary); margin-bottom: var(--space-4);
+}
+.home-hero h1 { font-size: 48px; margin-bottom: var(--space-4); }
+.home-hero .lead {
+    font-size: 18px; color: var(--color-muted); max-width: 520px; margin: 0 auto var(--space-8);
+}
+.home-hero .actions { display: inline-flex; gap: var(--space-3); }
+@media (max-width: 640px) {
+    .home-hero h1 { font-size: 34px; }
+    .home-hero .lead { font-size: 16px; }
+    .home-hero .actions { flex-direction: column; width: 100%; max-width: 320px; }
+    .home-hero .actions .btn { width: 100%; }
+}
+```
+
+- [ ] **Step 2: Rewrite home.php**
+
+Overwrite `plataforma/application/views/home.php` with:
+
+```php
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <?php $this->load->view('header'); ?>
+</head>
+<body>
+    <header class="topbar">
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk</a>
+        <nav>
+            <a href="<?php echo base_url('about'); ?>">About</a>
+        </nav>
+    </header>
+
+    <main class="home-hero">
+        <div class="eyebrow">Clinical Risk Assessment</div>
+        <h1>AFibRisk</h1>
+        <p class="lead">A research tool that aggregates 17 clinical scores for Atrial Fibrillation risk prediction from published literature.</p>
+        <div class="actions">
+            <a href="<?php echo base_url('questions'); ?>" class="btn btn-primary">Start assessment</a>
+            <a href="<?php echo base_url('about'); ?>" class="btn btn-secondary">About</a>
+        </div>
+    </main>
+
+    <?php $this->load->view('footer'); ?>
+</body>
+</html>
+```
+
+- [ ] **Step 3: Verify manually**
+
+Reload `http://localhost/afibrisk/plataforma/`. Expected: dark topbar with "AFibRisk" + "About" link; centered hero with eyebrow, large title, muted lead text, and two buttons. Click "Start assessment" — should navigate to `/questions`. Resize window to 375px — actions stack vertically and become full-width. Take a screenshot.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/application/views/home.php plataforma/assets/css/style.css
+git commit -m "Rewrite landing page with hero layout"
+```
+
+---
+
+## Task 5: About page — sobre.php
+
+**Files:**
+- Modify (rewrite): `plataforma/application/views/sobre.php`
+- Modify (append): `plataforma/assets/css/style.css`
+
+- [ ] **Step 1: Append about-specific styles to style.css**
+
+Append to `plataforma/assets/css/style.css`:
+
+```css
+/* ============================================================================
+   About page
+   ============================================================================ */
+.about-section { margin-bottom: var(--space-8); }
+.about-section h2 { font-size: 18px; margin-bottom: var(--space-3); }
+.about-section p  { color: var(--color-ink-2); }
+.about-credits p { margin-bottom: var(--space-1); color: var(--color-muted); font-size: 14px; }
+.about-credits p:first-child { color: var(--color-ink); font-weight: 600; font-size: 15px; }
+.disclaimer-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-danger);
+    border-radius: var(--radius);
+    padding: var(--space-6);
+    box-shadow: var(--shadow-sm);
+}
+.disclaimer-card h2 { color: var(--color-danger); text-transform: uppercase; letter-spacing: 0.05em; font-size: 13px; }
+.disclaimer-card p { font-size: 13px; color: var(--color-ink-2); margin-bottom: var(--space-3); }
+.disclaimer-card p:last-child { margin-bottom: 0; }
+```
+
+- [ ] **Step 2: Rewrite sobre.php**
+
+Overwrite `plataforma/application/views/sobre.php` with:
+
+```php
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <?php $this->load->view('header'); ?>
+</head>
+<body>
+    <header class="topbar">
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk</a>
+        <nav>
+            <a href="<?php echo base_url(); ?>">Home</a>
+        </nav>
+    </header>
+
+    <main class="container-narrow">
+        <h1>About AFibRisk</h1>
+
+        <section class="about-section about-credits">
+            <p>Created by Joao Brainer C de Andrade, MD, PhD</p>
+            <p>Universidade Federal de São Paulo, Brazil</p>
+            <p>Department of Health Informatics</p>
+            <p>Department of Neurology</p>
+            <p><a href="mailto:joao.brainer@unifesp.br">joao.brainer@unifesp.br</a></p>
+        </section>
+
+        <section class="about-section">
+            <p>Application developed by <a href="https://www.linkedin.com/in/danielsciarotta/" target="_blank" rel="noopener">Daniel Sciarotta Zaveri</a>.</p>
+        </section>
+
+        <section class="disclaimer-card">
+            <h2>Disclaimer</h2>
+            <p>This application is made available solely for personal non-commercial, teaching and educational use. This application is NOT a medical device and does not and should not be construed to provide health-related or medical advice, or clinical decision support, or to support or replace the diagnosis, or another kind of medical decision. This application does not create a physician–patient relationship between the above-mentioned institutions and any individual. You, the user, agree to use this application under all these terms and conditions. If you do not agree to all of these terms of use, do not use this site.</p>
+            <p>Dr. Joao Andrade and the developers make no representations as to any matter whatsoever, including accuracy, fitness for a particular purpose or non-infringement.</p>
+            <p>Dr. Joao Andrade and the developers are not liable to you or anyone else for any decision made or action taken based on reliance upon the information contained on or provided through this website. The use of the information shall be at your own risk.</p>
+        </section>
+    </main>
+
+    <?php $this->load->view('footer'); ?>
+</body>
+</html>
+```
+
+- [ ] **Step 3: Verify manually**
+
+Visit `http://localhost/afibrisk/plataforma/about`. Expected: topbar, narrow container with title "About AFibRisk", credits section, and a disclaimer card with a red left border. Text should be readable. Take a screenshot.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/application/views/sobre.php plataforma/assets/css/style.css
+git commit -m "Rewrite about page with narrow container and disclaimer card"
+```
+
+---
+
+## Task 6: Questions page — markup rewrite
+
+**Files:**
+- Modify (rewrite): `plataforma/application/views/perguntas/home.php`
+- Modify (append): `plataforma/assets/css/style.css`
+
+This task is the biggest of the plan. It produces the full new markup for the questions page with sidebar layout, sections, and pill radios — but NO JS behaviors yet (those come in Task 7). The form will be functional (can submit), just without scroll-spy, progress, drawer, or conditional fields.
+
+- [ ] **Step 1: Append questions-page styles to style.css**
+
+Append to `plataforma/assets/css/style.css`:
+
+```css
+/* ============================================================================
+   Questions page layout
+   ============================================================================ */
+.questions-shell {
+    display: grid;
+    grid-template-columns: var(--sidebar-w) 1fr;
+    min-height: calc(100vh - var(--topbar-h));
+}
+
+.sidebar {
+    position: sticky; top: var(--topbar-h);
+    height: calc(100vh - var(--topbar-h));
+    padding: var(--space-6) var(--space-4);
+    background: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    display: flex; flex-direction: column; gap: var(--space-4);
+    overflow-y: auto;
+}
+.sidebar h2 {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--color-muted);
+    margin-bottom: var(--space-2);
+}
+.sidebar ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.sidebar li a {
+    display: flex; align-items: center; gap: var(--space-2);
+    padding: 8px 10px; border-radius: var(--radius-sm);
+    color: var(--color-ink-2); font-size: 14px; font-weight: 500;
+    text-decoration: none;
+}
+.sidebar li a:hover { background: var(--color-surface-alt); text-decoration: none; }
+.sidebar li a .marker {
+    width: 18px; height: 18px; flex: 0 0 18px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: 1.5px solid var(--color-border); border-radius: 50%;
+    color: var(--color-muted); font-size: 11px; font-weight: 700;
+}
+.sidebar li a.active { background: rgba(37, 99, 235, 0.08); color: var(--color-primary); }
+.sidebar li a.active .marker { border-color: var(--color-primary); background: var(--color-primary); color: #fff; }
+.sidebar li a.done .marker { border-color: var(--color-success); background: var(--color-success); color: #fff; }
+.sidebar li a.done .marker::before { content: "✓"; }
+
+.sidebar .progress { margin-top: auto; padding-top: var(--space-4); border-top: 1px solid var(--color-border); }
+.sidebar .progress-label { display: flex; justify-content: space-between; font-size: 12px; color: var(--color-muted); margin-bottom: 6px; }
+.sidebar .progress-bar { height: 6px; background: var(--color-border); border-radius: 999px; overflow: hidden; }
+.sidebar .progress-fill { height: 100%; background: var(--color-primary); width: 0%; transition: width 180ms ease; }
+.sidebar .btn-calculate-wrap { margin-top: var(--space-4); }
+.sidebar .btn-calculate-wrap .btn { width: 100%; }
+
+.questions-content { padding: var(--space-8) var(--space-6); max-width: 880px; }
+.question-section { scroll-margin-top: calc(var(--topbar-h) + var(--space-4)); margin-bottom: var(--space-12); }
+.question-section h2 { font-size: 22px; }
+.question-section .section-hint { color: var(--color-muted); font-size: 14px; margin-bottom: var(--space-6); }
+.question-section .field-row { margin-bottom: var(--space-4); }
+.question-section .divider { height: 1px; background: var(--color-border); margin: var(--space-8) 0; }
+
+.section-nav { display: flex; justify-content: space-between; gap: var(--space-3); margin-top: var(--space-6); }
+.section-nav .btn[data-disabled="true"] { visibility: hidden; }
+
+.tooltip-trigger {
+    display: inline-block; margin-left: 6px;
+    width: 16px; height: 16px; line-height: 16px; text-align: center;
+    border-radius: 50%; border: 1px solid var(--color-border);
+    color: var(--color-muted); font-size: 11px; font-weight: 700;
+    cursor: help;
+}
+.tooltip-trigger:hover { color: var(--color-primary); border-color: var(--color-primary); }
+
+.drawer-backdrop { display: none; }
+
+@media (max-width: 1023px) {
+    :root { --sidebar-w: 220px; }
+    .questions-content .field-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 767px) {
+    .questions-shell { grid-template-columns: 1fr; }
+    .topbar .hamburger { display: inline-flex; }
+    .sidebar {
+        position: fixed; top: var(--topbar-h); left: 0;
+        width: 85%; max-width: 320px; height: calc(100vh - var(--topbar-h));
+        z-index: 15;
+        transform: translateX(-100%);
+        transition: transform 220ms ease;
+        border-right: 1px solid var(--color-border);
+        box-shadow: var(--shadow);
+    }
+    .sidebar.open { transform: translateX(0); }
+    .drawer-backdrop {
+        display: block; position: fixed; inset: var(--topbar-h) 0 0 0;
+        background: rgba(15, 23, 42, 0.5);
+        opacity: 0; pointer-events: none; transition: opacity 200ms;
+        z-index: 14;
+    }
+    .drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+    .questions-content { padding: var(--space-6) var(--space-4) 96px; }
+    .sidebar .btn-calculate-wrap { display: none; }
+    .mobile-submit {
+        position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-surface);
+        border-top: 1px solid var(--color-border);
+    }
+    .mobile-submit .btn { width: 100%; }
+}
+@media (min-width: 768px) {
+    .mobile-submit { display: none; }
+}
+```
+
+- [ ] **Step 2: Rewrite perguntas/home.php — full markup**
+
+Overwrite `plataforma/application/views/perguntas/home.php` with:
+
+```php
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <?php $this->load->view('header'); ?>
+</head>
+<body>
+    <header class="topbar">
+        <button type="button" class="hamburger" id="drawerToggle" aria-label="Open sections" aria-expanded="false">&#9776;</button>
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk / Assessment</a>
+        <nav>
+            <a href="<?php echo base_url('about'); ?>">About</a>
+        </nav>
+    </header>
+
+    <div class="drawer-backdrop" id="drawerBackdrop"></div>
+
+    <?= form_open("home/todasRespostas", 'id="formprincipal"'); ?>
+    <div class="questions-shell">
+        <aside class="sidebar" id="sidebar" aria-label="Sections">
+            <h2>Sections</h2>
+            <ul>
+                <li><a href="#demographic"     data-section="demographic"><span class="marker">1</span> Demographic</a></li>
+                <li><a href="#neurological"    data-section="neurological"><span class="marker">2</span> Neurological</a></li>
+                <li><a href="#body-metrics"    data-section="body-metrics"><span class="marker">3</span> Body metrics</a></li>
+                <li><a href="#history"         data-section="history"><span class="marker">4</span> Personal history</a></li>
+                <li><a href="#echography"      data-section="echography"><span class="marker">5</span> Echography</a></li>
+                <li><a href="#ecg"             data-section="ecg"><span class="marker">6</span> Electrocardiogram</a></li>
+                <li><a href="#cardiology"      data-section="cardiology"><span class="marker">7</span> Cardiology &amp; general</a></li>
+            </ul>
+
+            <div class="progress">
+                <div class="progress-label"><span>Progress</span><span id="progressPct">0%</span></div>
+                <div class="progress-bar"><div class="progress-fill" id="progressFill"></div></div>
+            </div>
+            <div class="btn-calculate-wrap">
+                <button type="submit" class="btn btn-primary">Calculate</button>
+            </div>
+        </aside>
+
+        <div class="questions-content">
+
+            <section class="question-section" id="demographic">
+                <h2>Demographic</h2>
+                <div class="field"><label for="age">Age</label>
+                    <input type="number" id="age" name="1_age" inputmode="numeric" min="0" max="120" autocomplete="off">
+                </div>
+                <div class="field"><label>Gender</label>
+                    <div class="pill-group">
+                        <input type="radio" id="gender_male" name="2_gender" value="male"><label for="gender_male">Male</label>
+                        <input type="radio" id="gender_female" name="2_gender" value="female"><label for="gender_female">Female</label>
+                    </div>
+                </div>
+                <div class="field"><label>White</label>
+                    <div class="pill-group">
+                        <input type="radio" id="white_yes" name="27_white" value="yes"><label for="white_yes">Yes</label>
+                        <input type="radio" id="white_no"  name="27_white" value="no"><label for="white_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Black</label>
+                    <div class="pill-group">
+                        <input type="radio" id="black_yes" name="28_black" value="yes"><label for="black_yes">Yes</label>
+                        <input type="radio" id="black_no"  name="28_black" value="no"><label for="black_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="neurological">
+                <h2>Neurological</h2>
+                <div class="field"><label for="nihss">NIH Stroke Scale on admission</label>
+                    <input type="number" id="nihss" name="3_nihss" inputmode="numeric" min="0" max="42" autocomplete="off">
+                </div>
+                <div class="field"><label>Previous Stroke or Transient Ischemic Attack</label>
+                    <div class="pill-group">
+                        <input type="radio" id="stroke_yes" name="30_stroke" value="yes"><label for="stroke_yes">Yes</label>
+                        <input type="radio" id="stroke_no"  name="30_stroke" value="no"><label for="stroke_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="body-metrics">
+                <h2>Body metrics and laboratory</h2>
+                <div class="field-row">
+                    <div class="field"><label for="height_cm">Height (cm)</label>
+                        <input type="number" id="height_cm" name="12_height_cm" inputmode="numeric" autocomplete="off">
+                    </div>
+                    <div class="field"><label for="weight_kg">Weight (kg)</label>
+                        <input type="number" id="weight_kg" name="13_weight_kg" inputmode="numeric" autocomplete="off">
+                    </div>
+                </div>
+                <div class="field-row">
+                    <div class="field"><label for="systolic_bp">Systolic BP (mmHg)</label>
+                        <input type="number" id="systolic_bp" name="15_systolic_bp" inputmode="numeric" autocomplete="off">
+                    </div>
+                    <div class="field"><label for="diastolic_bp">Diastolic BP (mmHg)</label>
+                        <input type="number" id="diastolic_bp" name="16_diastolic_bp" inputmode="numeric" autocomplete="off">
+                    </div>
+                </div>
+                <div class="field"><label>Raised BMI (BMI &gt; 30 kg/m²)</label>
+                    <div class="pill-group">
+                        <input type="radio" id="raised_bmi_yes" name="20_raised_bmi" value="yes"><label for="raised_bmi_yes">Yes</label>
+                        <input type="radio" id="raised_bmi_no"  name="20_raised_bmi" value="no"><label for="raised_bmi_no">No</label>
+                    </div>
+                </div>
+                <div id="bmi_25_container" hidden>
+                    <div class="field"><label>BMI ≥ 25 kg/m²</label>
+                        <div class="pill-group">
+                            <input type="radio" id="bmi_25_yes" name="20_1_bmi_25" value="yes"><label for="bmi_25_yes">Yes</label>
+                            <input type="radio" id="bmi_25_no"  name="20_1_bmi_25" value="no"><label for="bmi_25_no">No</label>
+                        </div>
+                    </div>
+                    <div id="additional_bmi_content" hidden>
+                        <div class="field"><label for="bmi_value">BMI (kg/m²)</label>
+                            <input type="number" id="bmi_value" name="20_2_bmi_value" inputmode="decimal" step="0.01" autocomplete="off">
+                        </div>
+                    </div>
+                </div>
+                <div class="field-row">
+                    <div class="field"><label for="waist">Waist circumference (cm)</label>
+                        <input type="number" id="waist" name="34_waist_circumference" inputmode="numeric" autocomplete="off">
+                    </div>
+                    <div class="field"><label for="hr">Heart rate (bpm)</label>
+                        <input type="number" id="hr" name="35_heart_rate" inputmode="numeric" autocomplete="off">
+                    </div>
+                </div>
+                <div class="field"><label for="ldl">Cholesterol LDL-C (mg/dL)</label>
+                    <input type="number" id="ldl" name="33_cholesterol_ldl" inputmode="numeric" autocomplete="off">
+                </div>
+            </section>
+
+            <section class="question-section" id="history">
+                <h2>Personal history</h2>
+                <div class="field"><label>History of Coronary Disease</label>
+                    <div class="pill-group">
+                        <input type="radio" id="coronary_yes" name="6_coronary_disease" value="yes"><label for="coronary_yes">Yes</label>
+                        <input type="radio" id="coronary_no"  name="6_coronary_disease" value="no"><label for="coronary_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>History of COPD</label>
+                    <div class="pill-group">
+                        <input type="radio" id="copd_yes" name="7_copd" value="yes"><label for="copd_yes">Yes</label>
+                        <input type="radio" id="copd_no"  name="7_copd" value="no"><label for="copd_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>History of Arterial Hypertension</label>
+                    <div class="pill-group">
+                        <input type="radio" id="htn_yes" name="8_hypertension" value="yes"><label for="htn_yes">Yes</label>
+                        <input type="radio" id="htn_no"  name="8_hypertension" value="no"><label for="htn_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>History of Heart Failure</label>
+                    <div class="pill-group">
+                        <input type="radio" id="hf_yes" name="9_heart_failure" value="yes"><label for="hf_yes">Yes</label>
+                        <input type="radio" id="hf_no"  name="9_heart_failure" value="no"><label for="hf_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Known Hyperthyroidism</label>
+                    <div class="pill-group">
+                        <input type="radio" id="hyper_yes" name="10_hyperthyroidism" value="yes"><label for="hyper_yes">Yes</label>
+                        <input type="radio" id="hyper_no"  name="10_hyperthyroidism" value="no"><label for="hyper_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Smoking</label>
+                    <div class="pill-group">
+                        <input type="radio" id="smoking_yes" name="14_smoking" value="yes"><label for="smoking_yes">Yes</label>
+                        <input type="radio" id="smoking_no"  name="14_smoking" value="no"><label for="smoking_no">No</label>
+                    </div>
+                </div>
+                <div id="former_smoker_container" hidden>
+                    <div class="field"><label>Former smoker</label>
+                        <div class="pill-group">
+                            <input type="radio" id="former_yes" name="14_1_former_smoker" value="yes"><label for="former_yes">Yes</label>
+                            <input type="radio" id="former_no"  name="14_1_former_smoker" value="no"><label for="former_no">No</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="field"><label>History of Diabetes</label>
+                    <div class="pill-group">
+                        <input type="radio" id="dm_yes" name="17_diabetes" value="yes"><label for="dm_yes">Yes</label>
+                        <input type="radio" id="dm_no"  name="17_diabetes" value="no"><label for="dm_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Sleep apnea</label>
+                    <div class="pill-group">
+                        <input type="radio" id="sleep_yes" name="21_sleep_apnea" value="yes"><label for="sleep_yes">Yes</label>
+                        <input type="radio" id="sleep_no"  name="21_sleep_apnea" value="no"><label for="sleep_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Alcohol consumption</label>
+                    <div class="pill-group">
+                        <input type="radio" id="alc_0"    name="22_alcohol_consumption" value="0"><label for="alc_0">0</label>
+                        <input type="radio" id="alc_0_7"  name="22_alcohol_consumption" value="0_7"><label for="alc_0_7">0–7 / week</label>
+                        <input type="radio" id="alc_7_14" name="22_alcohol_consumption" value="7_14"><label for="alc_7_14">7–14 / week</label>
+                        <input type="radio" id="alc_15"   name="22_alcohol_consumption" value="15_plus"><label for="alc_15">15+ / week</label>
+                        <input type="radio" id="alc_none" name="22_alcohol_consumption" value="none"><label for="alc_none">None</label>
+                    </div>
+                </div>
+                <div class="field"><label>Peripheral Vascular Disease</label>
+                    <div class="pill-group">
+                        <input type="radio" id="pvd_yes" name="26_vascular_disease" value="yes"><label for="pvd_yes">Yes</label>
+                        <input type="radio" id="pvd_no"  name="26_vascular_disease" value="no"><label for="pvd_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>End-stage renal disease</label>
+                    <div class="pill-group">
+                        <input type="radio" id="renal_yes" name="31_renal_disease" value="yes"><label for="renal_yes">Yes</label>
+                        <input type="radio" id="renal_no"  name="31_renal_disease" value="no"><label for="renal_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="echography">
+                <h2>Echography</h2>
+                <div class="field"><label for="la_size">Left Atrium Size (mm)</label>
+                    <input type="number" id="la_size" name="4_left_atrium_size" inputmode="numeric" autocomplete="off">
+                </div>
+                <div class="field"><label>Presence of septal aneurysm</label>
+                    <div class="pill-group">
+                        <input type="radio" id="septal_yes" name="5_septal_aneurysm" value="yes"><label for="septal_yes">Yes</label>
+                        <input type="radio" id="septal_no"  name="5_septal_aneurysm" value="no"><label for="septal_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_1">Valve Disease <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="valve_yes" name="25_valve_disease" value="yes"><label for="valve_yes">Yes</label>
+                        <input type="radio" id="valve_no"  name="25_valve_disease" value="no"><label for="valve_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="ecg">
+                <h2>Electrocardiogram</h2>
+                <div class="field"><label>Left Ventricular Hypertrophy</label>
+                    <div class="pill-group">
+                        <input type="radio" id="lvh_yes" name="18_ecg_lv_hypertrophy" value="yes"><label for="lvh_yes">Yes</label>
+                        <input type="radio" id="lvh_no"  name="18_ecg_lv_hypertrophy" value="no"><label for="lvh_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label for="pr">PR Interval (ms)</label>
+                    <input type="number" id="pr" name="19_ecg_pr_interval" inputmode="numeric" autocomplete="off">
+                </div>
+                <div class="field"><label id="field_2">Presence of Left Atrial Enlargement <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="lae_yes" name="29_left_atrial_enlargement" value="yes"><label for="lae_yes">Yes</label>
+                        <input type="radio" id="lae_no"  name="29_left_atrial_enlargement" value="no"><label for="lae_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_3">Atrial premature contraction/complex <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="apc_yes" name="36_atrial_premature_contraction" value="yes"><label for="apc_yes">Yes</label>
+                        <input type="radio" id="apc_no"  name="36_atrial_premature_contraction" value="no"><label for="apc_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_4">Ventricular premature contraction/complex <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="vpc_yes" name="37_ventricular_premature_contraction" value="yes"><label for="vpc_yes">Yes</label>
+                        <input type="radio" id="vpc_no"  name="37_ventricular_premature_contraction" value="no"><label for="vpc_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Arrhythmia (other than AF)</label>
+                    <div class="pill-group">
+                        <input type="radio" id="arr_yes" name="32_arrhythmia" value="yes"><label for="arr_yes">Yes</label>
+                        <input type="radio" id="arr_no"  name="32_arrhythmia" value="no"><label for="arr_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="cardiology">
+                <h2>Cardiology and general</h2>
+                <div class="field"><label>Presence of symptomatic extra- or intracranial stenosis ≥50%, symptomatic arterial dissection, or clinico-radiological lacunar syndrome</label>
+                    <div class="pill-group">
+                        <input type="radio" id="sten_yes" name="23_symptomatic_stenosis" value="yes"><label for="sten_yes">Yes</label>
+                        <input type="radio" id="sten_no"  name="23_symptomatic_stenosis" value="no"><label for="sten_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_5">Significant Murmur <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="murmur_yes" name="24_significant_murmur" value="yes"><label for="murmur_yes">Yes</label>
+                        <input type="radio" id="murmur_no"  name="24_significant_murmur" value="no"><label for="murmur_no">No</label>
+                    </div>
+                </div>
+                <div id="precordial_murmur_container" hidden>
+                    <div class="field"><label>Presence of any precordial murmur</label>
+                        <div class="pill-group">
+                            <input type="radio" id="prec_yes" name="24_1_precordial_murmur" value="yes"><label for="prec_yes">Yes</label>
+                            <input type="radio" id="prec_no"  name="24_1_precordial_murmur" value="no"><label for="prec_no">No</label>
+                        </div>
+                    </div>
+                </div>
+                <div id="autoimmune_disease_container" hidden>
+                    <div class="field"><label>Presence of autoimmune / inflammatory disease</label>
+                        <div class="pill-group">
+                            <input type="radio" id="auto_yes" name="38_autoimmune_disease" value="yes"><label for="auto_yes">Yes</label>
+                            <input type="radio" id="auto_no"  name="38_autoimmune_disease" value="no"><label for="auto_no">No</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="field"><label>Presence of aortic plaque</label>
+                    <div class="pill-group">
+                        <input type="radio" id="aortic_yes" name="39_aortic_plaque" value="yes"><label for="aortic_yes">Yes</label>
+                        <input type="radio" id="aortic_no"  name="39_aortic_plaque" value="no"><label for="aortic_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label for="bnp">B-type natriuretic peptide (pg/ml)</label>
+                    <input type="number" id="bnp" name="40_bnp_level" inputmode="numeric" autocomplete="off">
+                </div>
+            </section>
+
+        </div>
+    </div>
+
+    <div class="mobile-submit">
+        <button type="submit" class="btn btn-primary">Calculate</button>
+    </div>
+    <?php echo form_close(); ?>
+
+    <?php $this->load->view('footer'); ?>
+</body>
+</html>
+```
+
+- [ ] **Step 3: Verify manually**
+
+Visit `http://localhost/afibrisk/plataforma/questions`. Expected:
+- Sidebar with 7 items visible on the left (desktop ≥1024px)
+- Form fields on the right, grouped under section headings
+- Click pill buttons — selected pill turns blue
+- Submit button in the sidebar labelled "Calculate"
+- No drawer behavior yet (will come in Task 7)
+- No scroll-spy yet (no item is highlighted during scroll)
+- No conditional fields yet — BMI ≥25, former smoker, precordial murmur, autoimmune are permanently hidden (via `hidden` attribute) and will remain so until Task 7
+
+Fill a couple of fields (age, gender, NIHSS) and submit. Should redirect to the results page (broken visually still, but it means the POST works).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/application/views/perguntas/home.php plataforma/assets/css/style.css
+git commit -m "Rewrite questions page with sidebar layout and pill radios"
+```
+
+---
+
+## Task 7: Questions page — JS behaviors
+
+**Files:**
+- Modify (append to `<script>` at bottom): `plataforma/application/views/perguntas/home.php`
+
+- [ ] **Step 1: Add the behavior script at the end of perguntas/home.php**
+
+Before the closing `</body>` tag (after the `<?php $this->load->view('footer'); ?>` line), append:
+
+```html
+<script>
+(function () {
+    const sidebar = document.getElementById('sidebar');
+    const drawerToggle = document.getElementById('drawerToggle');
+    const drawerBackdrop = document.getElementById('drawerBackdrop');
+    const progressFill = document.getElementById('progressFill');
+    const progressPct  = document.getElementById('progressPct');
+    const form = document.getElementById('formprincipal');
+    const sectionLinks = sidebar.querySelectorAll('a[data-section]');
+    const sections = Array.from(document.querySelectorAll('.question-section'));
+
+    // ---- Drawer (mobile) ----
+    function openDrawer() {
+        sidebar.classList.add('open');
+        drawerBackdrop.classList.add('open');
+        drawerToggle.setAttribute('aria-expanded', 'true');
+    }
+    function closeDrawer() {
+        sidebar.classList.remove('open');
+        drawerBackdrop.classList.remove('open');
+        drawerToggle.setAttribute('aria-expanded', 'false');
+    }
+    drawerToggle.addEventListener('click', () => {
+        sidebar.classList.contains('open') ? closeDrawer() : openDrawer();
+    });
+    drawerBackdrop.addEventListener('click', closeDrawer);
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDrawer(); });
+    sidebar.addEventListener('click', (e) => {
+        if (e.target.closest('a[data-section]') && window.innerWidth <= 767) closeDrawer();
+    });
+
+    // ---- Scroll-spy (IntersectionObserver) ----
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                const id = entry.target.id;
+                sectionLinks.forEach(a => a.classList.toggle('active', a.dataset.section === id));
+            }
+        });
+    }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
+    sections.forEach(s => observer.observe(s));
+
+    // ---- Smooth scroll from sidebar clicks ----
+    sectionLinks.forEach(link => {
+        link.addEventListener('click', (e) => {
+            const id = link.dataset.section;
+            const target = document.getElementById(id);
+            if (target) {
+                e.preventDefault();
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+
+    // ---- Progress + done markers ----
+    function updateProgress() {
+        let doneCount = 0;
+        sections.forEach(section => {
+            const inputs = section.querySelectorAll('input');
+            const filled = Array.from(inputs).some(inp => {
+                if (inp.type === 'radio') return inp.checked;
+                return inp.value && inp.value.trim() !== '';
+            });
+            const link = sidebar.querySelector(`a[data-section="${section.id}"]`);
+            if (link) link.classList.toggle('done', filled);
+            if (filled) doneCount++;
+        });
+        const pct = Math.round((doneCount / sections.length) * 100);
+        progressFill.style.width = pct + '%';
+        progressPct.textContent = pct + '%';
+    }
+    form.addEventListener('input', updateProgress);
+    form.addEventListener('change', updateProgress);
+    updateProgress();
+
+    // ---- Conditional fields (preserves existing behaviour) ----
+    function show(el) { if (el) el.hidden = false; }
+    function hide(el) { if (el) { el.hidden = true; el.querySelectorAll('input[type="radio"]').forEach(r => r.checked = false); el.querySelectorAll('input[type="number"], input[type="text"]').forEach(i => i.value = ''); } }
+
+    const bmi25Container = document.getElementById('bmi_25_container');
+    const bmi25Extra     = document.getElementById('additional_bmi_content');
+    const formerContainer = document.getElementById('former_smoker_container');
+    const precordialContainer = document.getElementById('precordial_murmur_container');
+    const autoimmuneContainer = document.getElementById('autoimmune_disease_container');
+
+    // Raised BMI: No → show bmi_25_container; Yes → hide both
+    document.querySelectorAll('input[name="20_raised_bmi"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'no') { show(bmi25Container); }
+        else { hide(bmi25Container); hide(bmi25Extra); }
+    }));
+    document.querySelectorAll('input[name="20_1_bmi_25"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'yes') show(bmi25Extra); else hide(bmi25Extra);
+    }));
+
+    // Smoking: No → show former smoker container
+    document.querySelectorAll('input[name="14_smoking"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'no') show(formerContainer); else hide(formerContainer);
+    }));
+
+    // Significant murmur: Yes → show precordial murmur
+    document.querySelectorAll('input[name="24_significant_murmur"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'yes') show(precordialContainer); else hide(precordialContainer);
+    }));
+
+    // Gender female → show autoimmune disease
+    document.querySelectorAll('input[name="2_gender"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'female') show(autoimmuneContainer); else hide(autoimmuneContainer);
+    }));
+
+    // ---- Tippy tooltips (preserves existing content) ----
+    if (window.tippy) {
+        tippy('#field_1', { content: 'Aortic, mitral, tricuspid, and/or pulmonary valve disease', theme: 'customTooltipCssTema' });
+        tippy('#field_2', { content: 'Left atrial enlargement (LAE) by ECG: p-wave duration ≥120 ms or p-wave amplitude >2.5 mm in II, or terminal p negativity in V1 (duration 0.04 s, depth 1 mm). By parasternal long-axis view, LAE = anteroposterior diameter ≥4.0 cm.', theme: 'customTooltipCssTema' });
+        tippy('#field_3', { content: 'Premature P wave (often different shape), narrow/normal QRS identical to other beats, a long pause after the PAC, normal/short/longer PR than sinus, post-extrasystolic pause.', theme: 'customTooltipCssTema' });
+        tippy('#field_4', { content: 'Premature QRS complexes unusually long (>120 ms), wide QRS, no preceding P wave, large T wave oriented opposite the major QRS deflection.', theme: 'customTooltipCssTema' });
+        tippy('#field_5', { content: 'Significant if grade ≥3/6 systolic or any diastolic murmur on auscultation.', theme: 'customTooltipCssTema' });
+    }
+})();
+</script>
+```
+
+- [ ] **Step 2: Verify manually**
+
+Reload `/questions`.
+
+1. **Pill selection** — click Yes/No; pill turns blue.
+2. **Progress** — fill Age; sidebar "Demographic" gets a green check and progress shows ~14% (1/7). Fill NIHSS; 29%.
+3. **Scroll-spy** — scroll down; the active item in the sidebar tracks the current section.
+4. **Sidebar click** — click "Echography"; page smooth-scrolls to that section.
+5. **Conditional fields** — tick "Raised BMI = No" → BMI ≥25 question appears. Tick "BMI ≥25 = Yes" → BMI value input appears. Tick "Gender = female" → autoimmune question appears on Cardiology section. Tick "Smoking = No" → former smoker appears. Tick "Significant murmur = Yes" → precordial murmur appears.
+6. **Tooltips** — hover the `i` badges next to Valve Disease, Left Atrial Enlargement, APC, VPC, Significant Murmur — each shows a dark tooltip.
+7. **Mobile (≤767px)** — resize or use DevTools device. Hamburger `☰` appears in the topbar. Sidebar is hidden. Click hamburger → drawer slides in; backdrop dims behind. Click backdrop or press Escape → drawer closes. Click any section link → drawer closes after scroll. Calculate button appears sticky at the bottom.
+8. **Full submission** — fill fields across multiple sections, click Calculate; page goes to results.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plataforma/application/views/perguntas/home.php
+git commit -m "Wire up scroll-spy, drawer, progress, conditional fields"
+```
+
+---
+
+## Task 8: Results page — markup rewrite
+
+**Files:**
+- Modify (rewrite): `plataforma/application/views/resultado/home.php`
+- Modify (append): `plataforma/assets/css/style.css`
+
+This task handles the markup + styling only. The export JS module comes in Tasks 9–11.
+
+- [ ] **Step 1: Append results-page styles to style.css**
+
+Append to `plataforma/assets/css/style.css`:
+
+```css
+/* ============================================================================
+   Results page
+   ============================================================================ */
+.results-shell { max-width: 960px; margin: 0 auto; padding: var(--space-8) var(--space-4); }
+.results-header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-4); }
+.results-header h1 { margin: 0; }
+.results-header .timestamp { color: var(--color-muted); font-size: 13px; }
+
+.toolbar {
+    position: sticky; top: var(--topbar-h); z-index: 10;
+    display: flex; flex-wrap: wrap; gap: var(--space-2);
+    padding: var(--space-3) 0;
+    background: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: var(--space-6);
+}
+.toolbar .btn { padding: 8px 14px; font-size: 13px; }
+.toolbar .btn i { font-size: 14px; }
+
+.result-card {
+    background: var(--color-surface); border: 1px solid var(--color-border);
+    border-radius: var(--radius); box-shadow: var(--shadow-sm);
+    padding: var(--space-6); margin-bottom: var(--space-4);
+}
+.result-card .card-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+.result-card h3 { margin: 0; font-size: 16px; }
+.result-card .value { font-family: var(--font-mono); font-size: 26px; font-weight: 700; color: var(--color-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+.result-card .ref-btn {
+    background: transparent; border: 0; color: var(--color-muted); cursor: pointer;
+    width: 28px; height: 28px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+}
+.result-card .ref-btn:hover { color: var(--color-primary); background: var(--color-surface-alt); }
+.result-card .interp { margin: var(--space-3) 0 0; padding-top: var(--space-3); border-top: 1px solid var(--color-border); font-size: 13px; color: var(--color-ink-2); line-height: 1.55; }
+.result-card .hamada-image { display: block; max-width: 360px; margin: var(--space-3) auto 0; border-radius: var(--radius-sm); }
+
+.empty-state { text-align: center; padding: var(--space-12) var(--space-4); color: var(--color-muted); }
+.empty-state h2 { color: var(--color-ink); }
+
+/* Toast (export.js will toggle .show) */
+.toast {
+    position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(20px);
+    background: var(--color-ink); color: #fff;
+    padding: 10px 16px; border-radius: var(--radius-sm);
+    font-size: 14px; font-weight: 500;
+    box-shadow: var(--shadow);
+    opacity: 0; pointer-events: none; z-index: 1000;
+    transition: opacity 180ms, transform 180ms;
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); pointer-events: auto; }
+.toast.success { background: var(--color-success); }
+.toast.error   { background: var(--color-danger); }
+
+/* Modal (references) — replaces Bootstrap modal */
+.modal-backdrop {
+    position: fixed; inset: 0; background: rgba(15, 23, 42, 0.5);
+    display: none; align-items: center; justify-content: center; z-index: 100;
+}
+.modal-backdrop.show { display: flex; }
+.modal-dialog {
+    background: var(--color-surface); border-radius: var(--radius-lg);
+    max-width: 720px; width: calc(100% - 32px); max-height: 85vh;
+    display: flex; flex-direction: column;
+    box-shadow: 0 20px 60px rgba(15,23,42,0.25);
+}
+.modal-head { display: flex; align-items: center; justify-content: space-between; padding: var(--space-4) var(--space-6); border-bottom: 1px solid var(--color-border); }
+.modal-head h2 { margin: 0; font-size: 18px; }
+.modal-close { background: transparent; border: 0; font-size: 22px; cursor: pointer; color: var(--color-muted); line-height: 1; }
+.modal-close:hover { color: var(--color-ink); }
+.modal-body { padding: var(--space-6); overflow-y: auto; }
+.modal-body .reference { display: none; }
+.modal-body .reference.active { display: block; }
+.modal-body .reference p { font-size: 14px; color: var(--color-ink-2); line-height: 1.6; }
+.modal-body .reference p:first-child b { color: var(--color-ink); }
+
+/* PDF template (offscreen) */
+.pdf-template {
+    position: absolute; left: -10000px; top: 0; width: 780px;
+    padding: 20px; background: #fff; color: #000;
+    font-family: var(--font-sans); font-size: 12px;
+}
+.pdf-template h1 { font-size: 20px; }
+.pdf-template h2 { font-size: 14px; margin-top: 18px; }
+.pdf-template .pdf-kv { display: grid; grid-template-columns: 200px 1fr; gap: 4px 12px; margin-bottom: 4px; font-size: 12px; }
+.pdf-template .pdf-kv span:first-child { color: #555; }
+.pdf-template .pdf-score { border-top: 1px solid #ddd; padding-top: 8px; margin-top: 6px; }
+.pdf-template .pdf-score strong { font-size: 13px; }
+.pdf-template .pdf-score .val { color: #2563eb; font-family: var(--font-mono); font-weight: 700; margin-left: 8px; }
+.pdf-template .pdf-ref { border-top: 1px solid #eee; padding-top: 6px; margin-top: 8px; font-size: 11px; color: #333; }
+.pdf-template footer { margin-top: 24px; padding-top: 12px; border-top: 2px solid #0f172a; font-size: 10px; color: #555; }
+
+@media (max-width: 640px) {
+    .toolbar .btn-label { display: none; }
+    .toolbar .btn { padding: 8px 10px; }
+}
+```
+
+- [ ] **Step 2: Rewrite resultado/home.php**
+
+Overwrite `plataforma/application/views/resultado/home.php` with the following. The PHP loop keeps all existing score-rendering logic (Hamada image case included). The reference modal content is preserved verbatim from the previous version since it's long and scientific — re-wrapped in the new modal classes.
+
+```php
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <?php $this->load->view('header'); ?>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha512-GsLlZN/3F2ErC5ifS5QtgpiJtWd43JWSuIgh7mbzZ8zBps+dvLusV+eNQATqgA/HdeKFVgA5v3S/cIrLF7QnIg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+<body>
+    <header class="topbar">
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk</a>
+        <nav>
+            <a href="<?php echo base_url('about'); ?>">About</a>
+        </nav>
+    </header>
+
+    <main class="results-shell">
+        <?php
+            $resultado = $this->session->userdata('resultados');
+            $respostas = $this->session->userdata('respostas') ?: array();
+            $hasResults = is_array($resultado) && count($resultado) > 0;
+        ?>
+
+        <?php if (!$hasResults): ?>
+            <div class="empty-state">
+                <h2>No assessment yet</h2>
+                <p>Fill out the questionnaire to see results here.</p>
+                <a href="<?php echo base_url('questions'); ?>" class="btn btn-primary">Start an assessment</a>
+            </div>
+        <?php else: ?>
+            <div class="results-header">
+                <h1>Results</h1>
+                <div class="timestamp" id="generatedAt"></div>
+            </div>
+
+            <div class="toolbar" role="toolbar" aria-label="Export results">
+                <button type="button" class="btn btn-secondary" data-action="copy"  aria-label="Copy to clipboard">📋 <span class="btn-label">Copy</span></button>
+                <button type="button" class="btn btn-secondary" data-action="pdf"   aria-label="Download PDF">📄 <span class="btn-label">PDF</span></button>
+                <button type="button" class="btn btn-secondary" data-action="csv"   aria-label="Download CSV">📊 <span class="btn-label">CSV</span></button>
+                <button type="button" class="btn btn-secondary" data-action="print" aria-label="Print">🖨 <span class="btn-label">Print</span></button>
+                <a href="<?php echo base_url('questions'); ?>" class="btn btn-ghost" style="margin-left:auto">↻ New assessment</a>
+            </div>
+
+            <div id="resultCards">
+                <?php foreach ($resultado as $key => $value):
+                    if ($value['resposta'] === 'none') continue;
+                    $id = str_replace(' ', '', $key);
+                    if (strpos($key, 'BRAFIL') !== false) $id = 'BRAFIL';
+                ?>
+                    <div class="result-card" data-score-name="<?= htmlspecialchars($key) ?>" data-score-value="<?= htmlspecialchars($value['resposta']) ?>">
+                        <div class="card-head">
+                            <h3><?= htmlspecialchars($key) ?></h3>
+                            <?php if ($key === 'Hamada'): ?>
+                                <span class="value">see chart</span>
+                            <?php else: ?>
+                                <span class="value"><?= htmlspecialchars($value['resposta']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($value['message'])): ?>
+                                <button type="button" class="ref-btn show-reference" data-ref="<?= $id ?>" aria-label="View reference"><i class="fas fa-info-circle"></i></button>
+                            <?php endif; ?>
+                        </div>
+                        <?php if ($key === 'Hamada'): ?>
+                            <img class="hamada-image" src="<?= base_url('assets/images/hamada/' . $value['resposta'] . '.png') ?>" alt="Hamada risk chart">
+                        <?php endif; ?>
+                        <?php if (!empty($value['interpretation'])): ?>
+                            <p class="interp"><?= htmlspecialchars($value['interpretation']) ?></p>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+
+            <!-- Inputs payload for export.js -->
+            <script>
+                window.AFIBRISK_INPUTS = <?= json_encode($respostas, JSON_UNESCAPED_UNICODE) ?>;
+            </script>
+
+            <!-- Offscreen PDF template: export.js fills `#pdfBody` on demand -->
+            <div class="pdf-template" id="pdfTemplate" aria-hidden="true">
+                <h1>AFibRisk — Assessment Report</h1>
+                <div id="pdfBody"></div>
+                <footer>
+                    Not a medical device. This report is for educational/research use only.
+                    See the About page for the full disclaimer.
+                </footer>
+            </div>
+
+            <!-- References modal (markup preserved from previous version, re-classed) -->
+            <div class="modal-backdrop" id="referenceModal" role="dialog" aria-modal="true" aria-labelledby="referenceModalLabel">
+                <div class="modal-dialog">
+                    <div class="modal-head">
+                        <h2 id="referenceModalLabel">Reference</h2>
+                        <button type="button" class="modal-close" aria-label="Close">×</button>
+                    </div>
+                    <div class="modal-body" id="referenceBody">
+                        <!-- Keep all <div class="reference <KEY>"> blocks from the previous version -->
+                        <div class="reference STAF">
+                            <p><b>Score for the Targeting of Atrial Fibrillation (STAF)</b></p>
+                            <p>Laurent Suissa, MD; David Bertora, MD; Sylvain Lachaud, MD; Marie Hélène Mahagne, MD, PhD</p>
+                            <p>STAF, calculated from the sum of the points for the 4 items (possible total score 0 to 8): age ≥62 years (2 points); NIHSS ≥8 (1 point); left atrial dilatation (2 points); absence of symptomatic intra/extracranial stenosis ≥50% or clinico-radiological lacunar syndrome (3 points). STAF ≥5 identified patients with AF with sensitivity 89% and specificity 88%.</p>
+                            <p><b>DOI: 10.1161/STROKEAHA.109.552679</b></p>
+                        </div>
+                        <div class="reference BRAFIL">
+                            <p><b>A predictive score of Atrial Fibrillation in post-stroke patients</b></p>
+                            <p>Teixeira CT, Rizelio V, Robles A, Barros LCM, Silva GS, Andrade JBC.</p>
+                            <p>Score built with left atrial diameter ≥42 mm (2), age ≥70 years (1), septal aneurysm (2), NIHSS ≥6 at admission (1). Range 0–6. Score ≥2 → 5-fold AF risk. AUC 0.77 (0.72–0.85).</p>
+                        </div>
+                        <div class="reference TheHeinzNixdorfRecallStudy">
+                            <p><b>B-type natriuretic peptide for incident AF — Heinz Nixdorf Recall Study</b></p>
+                            <p>Kara K, Geisel MH, Möhlenkamp S, et al.</p>
+                            <p>Elevated BNP levels are associated with significant excess of incident AF, independent of traditional risk factors. Gender-specific thresholds: ≥31 pg/ml male, ≥45 pg/ml female.</p>
+                            <p><b>doi: 10.1016/j.jjcc.2014.08.003</b></p>
+                        </div>
+                        <div class="reference ASAS">
+                            <p><b>Acute Stroke Atrial Fibrillation Scoring System (ASAS)</b></p>
+                            <p>Figueiredo MM, Rodrigues ACT, Alves MB, Cendoroglo Neto M, Silva GS.</p>
+                            <p>AF predictors: age, NIHSS, presence of left atrial enlargement. AUC 0.79 derivation, 0.76 validation.</p>
+                            <p><b>DOI: 10.6061/clinics/2014(04)04</b></p>
+                        </div>
+                        <div class="reference CHA2DS2-VASC">
+                            <p><b>CHADS2 / CHA2DS2-VASc for new-onset AF</b></p>
+                            <p>Saliba W, Gronich N, Barnett-Griness O, Rennert G.</p>
+                            <p>Each 1-point increase in CHA2DS2-VASc: hazard ratio 1.57 (95% CI 1.56–1.58). AUC for predicting new-onset AF: 0.744.</p>
+                            <p><b>PMID: 27012854 · DOI: 10.1016/j.amjmed.2016.02.029</b></p>
+                        </div>
+                        <div class="reference C2HEST">
+                            <p><b>C2HEST score for AF risk — meta-analysis</b></p>
+                            <p>Haybar H, Shirbandi K, Rahim F.</p>
+                            <p>Each 1-point increase: OR 1.03 (95% CI 1.01–1.05). Overall AUC 0.91 (0.85–0.96).</p>
+                            <p><b>PMID: 34862957 · DOI: 10.1186/s43044-021-00230-0</b></p>
+                        </div>
+                        <div class="reference Takase">
+                            <p><b>Prediction of AF by B-type Natriuretic Peptide</b></p>
+                            <p>Takase H, Dohi Y, Sonoda H, Kimura G.</p>
+                            <p>BNP as continuous variable: HR 5.65 (95% CI 2.63–12.41) for new-onset AF, adjusted for risk factors.</p>
+                            <p><b>DOI: 10.4022/jafib.674</b></p>
+                        </div>
+                        <div class="reference HAVOC">
+                            <p><b>HAVOC — A Clinical Score for Predicting AF in Cryptogenic Stroke/TIA</b></p>
+                            <p>Kwong C, Ling AY, Crawford MH, Zhao SX, Shah NH.</p>
+                            <p>7 clinical variables (age ≥75, obesity, CHF, hypertension, CAD, PVD, valve disease). AUC 0.77.</p>
+                            <p><b>PMID: 28654919 · DOI: 10.1159/000476030</b></p>
+                        </div>
+                        <div class="reference CHARGE-AF">
+                            <p><b>CHARGE-AF — Simple risk model for AF incidence</b></p>
+                            <p>Alonso A, Krijthe BP, Aspelund T, et al.</p>
+                            <p>5-year model (age, race, height, weight, BP, smoking, antihypertensive use, diabetes, MI, HF). Derivation C-statistic 0.765.</p>
+                            <p><b>PMID: 23537808 · DOI: 10.1161/JAHA.112.000102</b></p>
+                        </div>
+                        <div class="reference HARMS2-AF">
+                            <p><b>HARMS2-AF — New-onset AF lifestyle risk score</b></p>
+                            <p>Segan L, Canovas R, Nanayakkara S, et al.</p>
+                            <p>Predictors: hypertension, age, BMI, male sex, sleep apnoea, smoking, alcohol. 5-year AUC 0.757; 10-year AUC 0.753.</p>
+                            <p><b>PMID: 37350480 · DOI: 10.1093/eurheartj/ehad375</b></p>
+                        </div>
+                        <div class="reference Hamada">
+                            <p><b>Simple risk model and score for predicting incident AF in Japanese</b></p>
+                            <p>Hamada R, Muto S.</p>
+                            <p>7-year model (age, waist circumference, diastolic BP, alcohol, heart rate, cardiac murmur) + ECG add-on (LVH, atrial enlargement, APC, VPC). C-statistic 0.77 simple, 0.78 added.</p>
+                            <p><b>DOI: 10.1016/j.jjcc.2018.06.005</b></p>
+                        </div>
+                        <div class="reference MayoScore">
+                            <p><b>Clinical Predictors of Risk for AF — Mayo</b></p>
+                            <p>Brunner KJ, Bunch TJ, Mullin CM, et al.</p>
+                            <p>7 validated risk factors. AUC 0.812 (95% CI 0.805–0.820).</p>
+                            <p><b>DOI: 10.1016/j.mayocp.2014.08.016</b></p>
+                        </div>
+                        <div class="reference HATCH">
+                            <p><b>HATCH score in Asians</b></p>
+                            <p>Suenari K, Chao TF, Liu CJ, Kihara Y, Chen TJ, Chen SA.</p>
+                            <p>Hypertension (1), age &gt;75 (1), stroke/TIA (2), COPD (1), heart failure (2). HR per 1-point increase 2.059 (2.027–2.093).</p>
+                            <p><b>DOI: 10.1097/MD.0000000000005597</b></p>
+                        </div>
+                        <div class="reference FraminghamAFriskscore">
+                            <p><b>Framingham AF Risk Score</b></p>
+                            <p>Schnabel RB, Sullivan LM, Levy D, et al.</p>
+                            <p>Variables: age, sex, significant murmur, HF, systolic BP, hypertension treatment, BMI, ECG PR interval. C-statistic 0.78.</p>
+                            <p><b>DOI: 10.1016/S0140-6736(09)60443-8</b></p>
+                        </div>
+                        <div class="reference MHSScore">
+                            <p><b>MHS 10-year AF Risk Score</b></p>
+                            <p>Aronson D, Shalev V, Katz R, Chodick G, Mutlak D.</p>
+                            <p>Variables: age, sex, BMI, treated hypertension, SBP &gt;160, chronic lung disease, MI, PAD, HF, inflammatory disease. C-statistic 0.743–0.749.</p>
+                            <p><b>DOI: 10.1055/s-0038-1668522</b></p>
+                        </div>
+                        <div class="reference ARICScore">
+                            <p><b>ARIC Risk Score for AF</b></p>
+                            <p>Chamberlain AM, Agarwal SK, Folsom AR, et al.</p>
+                            <p>Variables: age, race, height, smoking, SBP, hypertension treatment, precordial murmur, LVH, LAE, diabetes, CHD, HF. AUC 0.76.</p>
+                            <p><b>DOI: 10.1016/j.amjcard.2010.08.049</b></p>
+                        </div>
+                        <div class="reference Suita">
+                            <p><b>Suita Study — Japanese 10-year AF risk</b></p>
+                            <p>Kokubo Y, Watanabe M, Higashiyama A, Nakao YM, Kusano K, Miyamoto Y.</p>
+                            <p>C-statistic 0.749 (95% CI 0.724–0.774). Score ≤2 → ≤1%; 10–11 → 9%; ≥16 → 27% observed 10-year AF probability.</p>
+                            <p><b>DOI: 10.1253/circj.CJ-17-0277</b></p>
+                        </div>
+                        <div class="reference TaiwanAFScore">
+                            <p><b>Taiwan AF Score</b></p>
+                            <p>Chao TF, Chiang CE, Chen TJ, Liao JN, Tuan TC, Chen SA.</p>
+                            <p>Age, male sex, hypertension, HF, CAD, ESRD, alcoholism. Range −2 to 15. AUC: 0.857 (1-yr), 0.825 (5-yr), 0.797 (10-yr), 0.756 (16-yr).</p>
+                            <p><b>DOI: 10.1161/JAHA.120.020194</b></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
+    </main>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <?php $this->load->view('footer'); ?>
+    <script src="<?php echo base_url('assets/js/export.js'); ?>"></script>
+
+    <script>
+        // Reference modal + score tooltips — kept from the previous version
+        (function(){
+            const modal = document.getElementById('referenceModal');
+            const closeBtn = modal ? modal.querySelector('.modal-close') : null;
+            const refs = modal ? modal.querySelectorAll('.reference') : [];
+            function openModal(id) {
+                refs.forEach(r => r.classList.toggle('active', r.classList.contains(id)));
+                modal.classList.add('show');
+            }
+            function closeModal() { if (modal) modal.classList.remove('show'); }
+            document.querySelectorAll('.show-reference').forEach(btn => {
+                btn.addEventListener('click', () => openModal(btn.dataset.ref));
+            });
+            if (closeBtn) closeBtn.addEventListener('click', closeModal);
+            if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+            document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeModal(); });
+
+            // Score tooltips — attach to each .ref-btn by score key
+            if (!window.tippy) return;
+            const tips = {
+                STAF: 'A total score of ≥5 identifies patients with AF with sensitivity 89% and specificity 88%.',
+                ASAS: 'AUC 0.78 (95% CI 0.70–0.86), excluding previous AF diagnosis.',
+                'CHA2DS2-VASC': 'AUC 0.744 for new-onset AF over 2-year follow-up.',
+                HAVOC: 'Chance (%) of AF in 3 years; AUC 0.77.',
+                'CHARGE-AF': 'Chance (%) of AF in 5 years.',
+                'HARMS2-AF': 'Hazard ratio for AF detection up to 10 years. 5-year AUC 0.757; 10-year AUC 0.753.',
+                Hamada: '7-year risk of AF; AUC 0.78.',
+                MayoScore: 'Incident AF in ~8-year follow-up; AUC 0.812.',
+                HATCH: 'Chance of AF detection in ~10 years; AUC 0.716.',
+                MHSScore: '10-year predicted risk of AF; AUC 0.749.',
+                ARICScore: 'Chance (%) of AF in 10 years; AUC 0.76.',
+                Suita: '10-year predicted risk of AF; AUC 0.749.',
+                TaiwanAFScore: 'Cumulative incidence of AF in 1–16 year follow-up; AUC 0.857 (1yr) to 0.756 (16yr).'
+            };
+            document.querySelectorAll('.ref-btn').forEach(btn => {
+                const key = btn.dataset.ref;
+                if (tips[key]) tippy(btn, { content: tips[key], theme: 'customTooltipCssTema', placement: 'top' });
+            });
+        })();
+    </script>
+</body>
+</html>
+```
+
+Two PHP changes to be aware of that may require controller follow-up:
+- The markup reads `$value['interpretation']` as the **card body text**. The current controller does not set this key — it only sets `resposta` and `message`. If left as-is the interpretation line will simply not render (empty check) and the tooltip on the (i) icon still provides the context. This is acceptable for the first merge; populating `interpretation` per score is a follow-up aligned with the spec's "promoting tippy content into card" goal but does not block this plan.
+
+- [ ] **Step 3: Verify manually**
+
+Submit a full questionnaire from `/questions`. On `/result`:
+- Topbar + Results header with timestamp placeholder (empty until Task 9 sets it)
+- Toolbar with 4 icon buttons (Copy / PDF / CSV / Print) and a "New assessment" link — buttons don't do anything yet (export.js not loaded; file doesn't exist). 404 is expected for `export.js` — check Network tab.
+- Result cards uniform (white, shadow, rounded); score value in blue monospace on the right; (i) icon opens the references modal with the correct score reference highlighted.
+- Click (i) icon → modal appears with matching reference. Click backdrop or × → closes. Escape also closes.
+- Navigate directly to `/result` in a new session (or clear cookies) → empty state appears with "Start an assessment" button.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plataforma/application/views/resultado/home.php plataforma/assets/css/style.css
+git commit -m "Rewrite results page with toolbar, cards, and reference modal"
+```
+
+---
+
+## Task 9: export.js — Copy + toast scaffolding
+
+**Files:**
+- Create: `plataforma/assets/js/export.js`
+
+- [ ] **Step 1: Create export.js with the shared payload builder and Copy handler**
+
+Create `plataforma/assets/js/export.js`:
+
+```js
+(function () {
+    'use strict';
+
+    // ---- Payload ---------------------------------------------------------
+    function pad2(n) { return String(n).padStart(2, '0'); }
+    function nowISOLocal() {
+        const d = new Date();
+        const tz = -d.getTimezoneOffset();
+        const sign = tz >= 0 ? '+' : '-';
+        const abs = Math.abs(tz);
+        return d.getFullYear() + '-' + pad2(d.getMonth()+1) + '-' + pad2(d.getDate())
+             + 'T' + pad2(d.getHours()) + ':' + pad2(d.getMinutes()) + ':' + pad2(d.getSeconds())
+             + sign + pad2(Math.floor(abs/60)) + ':' + pad2(abs%60);
+    }
+    function nowHuman() {
+        const d = new Date();
+        return d.getFullYear() + '-' + pad2(d.getMonth()+1) + '-' + pad2(d.getDate())
+             + ' ' + pad2(d.getHours()) + ':' + pad2(d.getMinutes());
+    }
+    function nowFilename() {
+        const d = new Date();
+        return d.getFullYear() + '-' + pad2(d.getMonth()+1) + '-' + pad2(d.getDate())
+             + '-' + pad2(d.getHours()) + pad2(d.getMinutes());
+    }
+
+    function readScores() {
+        const cards = document.querySelectorAll('#resultCards .result-card');
+        return Array.from(cards).map(card => ({
+            name: card.dataset.scoreName,
+            value: card.dataset.scoreValue,
+            interpretation: (card.querySelector('.interp') || {}).textContent || ''
+        }));
+    }
+
+    const payload = {
+        generatedAt: nowISOLocal(),
+        generatedHuman: nowHuman(),
+        inputs: window.AFIBRISK_INPUTS || {},
+        scores: readScores()
+    };
+
+    // Populate the "Generated on" timestamp in the header
+    const ts = document.getElementById('generatedAt');
+    if (ts) ts.textContent = 'Generated on ' + payload.generatedHuman;
+
+    // ---- Toast ----------------------------------------------------------
+    const toastEl = document.getElementById('toast');
+    let toastTimer = null;
+    function toast(msg, kind) {
+        if (!toastEl) return;
+        toastEl.textContent = msg;
+        toastEl.className = 'toast show' + (kind ? ' ' + kind : '');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => { toastEl.classList.remove('show'); }, 2200);
+    }
+
+    // ---- Copy ----------------------------------------------------------
+    function formatPlainText() {
+        const lines = [];
+        lines.push('AFibRisk — Assessment');
+        lines.push('Generated: ' + payload.generatedHuman);
+        lines.push('');
+        lines.push('Scores');
+        payload.scores.forEach(s => {
+            lines.push('- ' + s.name + ': ' + s.value);
+        });
+        const inputKeys = Object.keys(payload.inputs);
+        if (inputKeys.length) {
+            lines.push('');
+            lines.push('Inputs');
+            inputKeys.forEach(k => {
+                const label = k.replace(/^\d+_?/, '').replace(/_/g, ' ');
+                lines.push('- ' + label + ': ' + payload.inputs[k]);
+            });
+        }
+        return lines.join('\n');
+    }
+
+    async function doCopy() {
+        const text = formatPlainText();
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                toast('Copied to clipboard', 'success'); return;
+            }
+        } catch (e) { /* fall through */ }
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed'; ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            if (ok) { toast('Copied to clipboard', 'success'); return; }
+        } catch (e) { /* fall through */ }
+        toast("Couldn't copy. Try Print instead.", 'error');
+    }
+
+    // ---- Print ---------------------------------------------------------
+    function doPrint() { window.print(); }
+
+    // Placeholders — implemented in Task 10 (CSV) and Task 11 (PDF)
+    function doCSV() { toast('CSV export not available yet', 'error'); }
+    function doPDF() { toast('PDF export not available yet', 'error'); }
+
+    // ---- Wire buttons --------------------------------------------------
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-action]');
+        if (!btn) return;
+        switch (btn.dataset.action) {
+            case 'copy':  doCopy();  break;
+            case 'pdf':   doPDF();   break;
+            case 'csv':   doCSV();   break;
+            case 'print': doPrint(); break;
+        }
+    });
+
+    // Expose for future testing hooks
+    window.AFibRisk = { payload, formatPlainText, nowFilename };
+})();
+```
+
+- [ ] **Step 2: Verify manually**
+
+Reload `/result`.
+
+1. The "Generated on YYYY-MM-DD HH:MM" appears next to the "Results" title.
+2. Click Copy — toast "Copied to clipboard" (green). Paste into Notepad — should show the formatted plain-text block starting with "AFibRisk — Assessment".
+3. Click Print — browser's print dialog opens (the print CSS comes in Task 12; preview will still include the toolbar for now).
+4. Click CSV / PDF — red toast "not available yet" (expected).
+5. Open DevTools console and inspect `window.AFibRisk.payload` — has `generatedAt`, `inputs`, `scores` fields.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plataforma/assets/js/export.js
+git commit -m "Add export.js with Copy, Print and payload builder"
+```
+
+---
+
+## Task 10: export.js — CSV
+
+**Files:**
+- Modify: `plataforma/assets/js/export.js`
+
+- [ ] **Step 1: Replace the CSV stub with a real implementation**
+
+In `plataforma/assets/js/export.js`, find:
+
+```js
+    function doCSV() { toast('CSV export not available yet', 'error'); }
+```
+
+Replace with:
+
+```js
+    function csvEscape(v) {
+        if (v === null || v === undefined) return '';
+        const s = String(v);
+        if (/[",\r\n]/.test(s)) return '"' + s.replace(/"/g, '""') + '"';
+        return s;
+    }
+
+    function doCSV() {
+        const inputKeys = Object.keys(payload.inputs);
+        const scoreKeys = payload.scores.map(s => 'score_' + s.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, ''));
+        const headers = ['generated_at', ...inputKeys, ...scoreKeys];
+        const row = [
+            payload.generatedAt,
+            ...inputKeys.map(k => payload.inputs[k]),
+            ...payload.scores.map(s => s.value)
+        ];
+        const csv = '\uFEFF'
+            + headers.map(csvEscape).join(',') + '\r\n'
+            + row.map(csvEscape).join(',') + '\r\n';
+
+        try {
+            const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'afibrisk-' + nowFilename() + '.csv';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+            toast('CSV downloaded', 'success');
+        } catch (e) {
+            toast("Couldn't export CSV", 'error');
+        }
+    }
+```
+
+- [ ] **Step 2: Verify manually**
+
+Reload `/result`.
+
+1. Click CSV → file `afibrisk-YYYY-MM-DD-HHmm.csv` downloads. Toast "CSV downloaded" (green).
+2. Open the file in a plain text editor — confirm:
+   - Starts with UTF-8 BOM (some editors show as `﻿` or nothing)
+   - Header row with `generated_at`, each input key, each score column prefixed `score_`
+   - Data row with ISO timestamp, values, and scores
+3. Open in Excel (or LibreOffice Calc) — accented characters render correctly (test by using a name with acento if possible — "Significant Murmur" etc. are fine). Each value lands in its own column.
+4. Import into Google Sheets via File → Import → Upload — same layout.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plataforma/assets/js/export.js
+git commit -m "Implement CSV export with UTF-8 BOM"
+```
+
+---
+
+## Task 11: export.js — PDF via html2pdf
+
+**Files:**
+- Modify: `plataforma/assets/js/export.js`
+
+- [ ] **Step 1: Replace the PDF stub with a real implementation**
+
+In `plataforma/assets/js/export.js`, find:
+
+```js
+    function doPDF() { toast('PDF export not available yet', 'error'); }
+```
+
+Replace with:
+
+```js
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function buildPdfBody() {
+        const parts = [];
+
+        // Header
+        parts.push('<div style="color:#64748b;font-size:11px;margin-bottom:16px">Generated on ' + escapeHtml(payload.generatedHuman) + '</div>');
+
+        // Inputs
+        const inputKeys = Object.keys(payload.inputs);
+        if (inputKeys.length) {
+            parts.push('<h2>Patient inputs</h2>');
+            inputKeys.forEach(k => {
+                const label = escapeHtml(k.replace(/^\d+_?/, '').replace(/_/g, ' '));
+                parts.push('<div class="pdf-kv"><span>' + label + '</span><span>' + escapeHtml(payload.inputs[k]) + '</span></div>');
+            });
+        }
+
+        // Scores
+        parts.push('<h2>Scores</h2>');
+        payload.scores.forEach(s => {
+            parts.push(
+                '<div class="pdf-score"><strong>' + escapeHtml(s.name) + '</strong>'
+                + '<span class="val">' + escapeHtml(s.value) + '</span>'
+                + (s.interpretation ? '<p style="margin:4px 0 0;font-size:11px;color:#333">' + escapeHtml(s.interpretation) + '</p>' : '')
+                + '</div>'
+            );
+        });
+
+        // References — reuse the DOM content from the modal
+        const modal = document.getElementById('referenceBody');
+        if (modal) {
+            parts.push('<h2>References</h2>');
+            payload.scores.forEach(s => {
+                const key = s.name.replace(/\s+/g, '');
+                const ref = modal.querySelector('.reference.' + CSS.escape(key))
+                         || (/BRAFIL/i.test(s.name) ? modal.querySelector('.reference.BRAFIL') : null);
+                if (ref) {
+                    parts.push('<div class="pdf-ref">' + ref.innerHTML + '</div>');
+                }
+            });
+        }
+
+        return parts.join('');
+    }
+
+    async function doPDF() {
+        if (typeof window.html2pdf === 'undefined') {
+            toast('PDF failed to generate. Try Print as a workaround.', 'error');
+            return;
+        }
+        const tpl = document.getElementById('pdfTemplate');
+        const body = document.getElementById('pdfBody');
+        if (!tpl || !body) return;
+
+        body.innerHTML = buildPdfBody();
+        try {
+            await window.html2pdf()
+                .from(tpl)
+                .set({
+                    filename: 'afibrisk-report-' + nowFilename() + '.pdf',
+                    margin: [15, 15, 15, 15],
+                    image: { type: 'jpeg', quality: 0.95 },
+                    html2canvas: { scale: 2, useCORS: true },
+                    jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+                    pagebreak: { mode: ['css', 'legacy'] }
+                })
+                .save();
+            toast('PDF downloaded', 'success');
+        } catch (e) {
+            toast('PDF failed to generate. Try Print as a workaround.', 'error');
+        } finally {
+            body.innerHTML = ''; // free memory
+        }
+    }
+```
+
+- [ ] **Step 2: Verify manually**
+
+Reload `/result` (now with an assessment in session).
+
+1. Click PDF → after 1–2s a file `afibrisk-report-YYYY-MM-DD-HHmm.pdf` downloads. Toast "PDF downloaded" (green).
+2. Open in Chrome's built-in PDF viewer:
+   - Page 1 has "AFibRisk — Assessment Report" header, timestamp, Patient Inputs (two-column key-value list), and start of Scores.
+   - Scores list each on its own row with value in blue and interpretation (if present).
+   - References section has bibliographic blocks for each computed score.
+   - Footer with disclaimer appears on the last page.
+   - References wrap across pages without cutting mid-sentence (CSS pagebreak).
+3. Open in Adobe Reader — same layout, text is selectable.
+4. **Offline test**: open DevTools Network tab → check "Offline" → reload `/result` → click PDF → expect red toast "PDF failed to generate. Try Print as a workaround." (because the CDN is blocked). Uncheck offline to restore.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plataforma/assets/js/export.js
+git commit -m "Implement PDF export with html2pdf and reference inlining"
+```
+
+---
+
+## Task 12: Print CSS, responsive polish, final verification
+
+**Files:**
+- Modify (append): `plataforma/assets/css/style.css`
+
+- [ ] **Step 1: Append @media print block to style.css**
+
+Append to `plataforma/assets/css/style.css`:
+
+```css
+/* ============================================================================
+   Print
+   ============================================================================ */
+@media print {
+    body { background: #fff; color: #000; }
+    .topbar, .toolbar, .mobile-submit, .drawer-backdrop, .modal-backdrop, .toast,
+    .sidebar, .ref-btn, .btn, .pdf-template { display: none !important; }
+    .results-shell { max-width: none; padding: 0; margin: 0; }
+    .results-header { display: block; margin-bottom: 16px; }
+    .results-header h1 { font-size: 22px; color: #000; }
+    .results-header .timestamp { font-size: 11px; color: #555; }
+    .result-card {
+        border: 1px solid #ccc !important; box-shadow: none !important;
+        page-break-inside: avoid; break-inside: avoid;
+        margin-bottom: 10px; padding: 10px;
+    }
+    .result-card .card-head { gap: 12px; }
+    .result-card h3 { font-size: 13px; color: #000; }
+    .result-card .value { color: #000; font-size: 16px; }
+    .result-card .interp { font-size: 11px; color: #000; border-top: 1px solid #ccc; }
+}
+```
+
+- [ ] **Step 2: Final end-to-end manual verification**
+
+Run through this checklist (from the spec's verification plan) and note any regressions:
+
+1. **Golden path** — `http://localhost/afibrisk/plataforma/` → Start → fill all 7 sections → Calculate → Results → Copy → paste in Notepad. Expected: formatted plain-text report with all scores and inputs.
+2. **Conditional fields** — on questions page: Raised BMI = No → BMI ≥25 appears; BMI ≥25 = Yes → BMI value input appears; Smoking = No → Former smoker appears; Significant murmur = Yes → Precordial murmur appears; Gender = female → Autoimmune disease appears.
+3. **Responsive** — DevTools device toolbar:
+   - 1440×900: sidebar 260px, form 2 columns where applicable, toolbar labels visible.
+   - 768×1024: sidebar 220px, form 1 column.
+   - 390×844 (iPhone 14): hamburger in topbar, drawer opens/closes, Calculate sticky at bottom, toolbar icons only.
+4. **Sidebar scroll-spy** — scroll through the questions page; active item in sidebar tracks viewport section.
+5. **Progress** — fill at least one field in 3 different sections → progress shows ~43% (3/7) and those 3 have green checkmarks.
+6. **CSV import** — open in Excel and Google Sheets; values in correct columns; accents render correctly.
+7. **PDF** — open in Chrome PDF viewer and Adobe Reader; references wrap cleanly; no cut-mid-paragraph issues.
+8. **Print preview** — Chrome and Firefox: only title + cards + generated-on timestamp appear; no topbar, no toolbar.
+9. **Keyboard a11y** — Tab traverses inputs in visual order on questions page; focus ring visible; Escape closes drawer and modal.
+10. **Browsers** — Chrome, Firefox, Edge (latest). Note: Safari not tested (no macOS environment available).
+11. **Empty results** — clear cookies or open `/result` in a fresh incognito window → empty state with Start-assessment button; no toolbar visible.
+
+Document any deviation as an issue in the PR, not as a code change here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plataforma/assets/css/style.css
+git commit -m "Add print CSS and finalize design refresh"
+```
+
+- [ ] **Step 4: Open the PR**
+
+Push the branch and open a PR with title `Design refresh + copy/export results`. Body:
+
+```
+## Summary
+- New "Dashboard Médico" visual identity: dark topbar, clinical blue, Inter typography
+- Questions page redesigned with sidebar navigation, scroll-spy, progress, drawer on mobile
+- Results page with Copy / PDF / CSV / Print toolbar and uniform cards
+- Controller untouched except for one line persisting raw inputs in session
+
+## Test plan
+- [ ] Fill questionnaire, verify conditional fields (BMI chain, smoker, murmur, autoimmune by gender)
+- [ ] Check sidebar scroll-spy + progress + drawer on mobile (≤767px)
+- [ ] Copy result → paste in text editor, format correct
+- [ ] CSV → opens cleanly in Excel and Google Sheets
+- [ ] PDF → opens in Chrome and Adobe Reader, references paginate correctly
+- [ ] Print preview shows only title + cards + timestamp
+- [ ] Empty state on /result with fresh session
+- [ ] Screenshots attached: home, questions desktop, questions mobile, results
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage** — every in-scope item has a task: tokens/base (T2), shared chrome (T3), home (T4), about (T5), questions markup (T6) + JS (T7), results markup (T8), export Copy (T9) + CSV (T10) + PDF (T11), print + final (T12), controller addition (T1). Out-of-scope items (badges, i18n) are intentionally absent.
+- **Placeholders** — no "TBD" / "TODO" / "add validation" style steps. Every code block is complete.
+- **Type/name consistency** — `data-action` values (`copy`/`pdf`/`csv`/`print`) match between the button markup (T8) and the click router (T9). `window.AFIBRISK_INPUTS` injection site (T8) matches reader (T9). Session key `respostas` matches between controller (T1) and view (T8).
+- **Interpretation field limitation noted** — the current controller does not populate `value['interpretation']`; cards will render without a body paragraph until a separate follow-up populates it. Tooltip on (i) still provides the context. Called out in T8.

--- a/docs/superpowers/specs/2026-04-17-design-refresh.md
+++ b/docs/superpowers/specs/2026-04-17-design-refresh.md
@@ -1,0 +1,304 @@
+# AFibRisk — Design refresh + Copy/Export results
+
+**Date:** 2026-04-17
+**Status:** Design approved, ready for implementation planning
+
+## Goal
+
+Reformulação geral do design do AFibRisk (CodeIgniter 3 medical AF risk-score calculator) para uma identidade moderna e profissional ("dashboard médico"), com navegação facilitada no formulário de 40+ campos, e botões de Copiar/Exportar resultados (PDF, CSV, Print, texto plano).
+
+## Scope
+
+**In scope**
+- Reescrita completa das views: `header.php`, `footer.php`, `home.php`, `sobre.php`, `perguntas/home.php`, `resultado/home.php`
+- Reescrita completa de `assets/css/style.css` com design tokens próprios
+- Novo arquivo `assets/js/export.js` (Copy, PDF, CSV, Print)
+- Remoção do Bootstrap 5 (substituído por CSS próprio)
+- Layout sidebar com navegação scroll-spy na página de perguntas
+- Drawer mobile para a sidebar
+- Tipografia Inter (substitui Multicolore Pro + Roboto Condensed)
+
+**Out of scope** (fase 2)
+- Badges de risco HIGH/MID/LOW por score (exige thresholds clínicos validados)
+- Internacionalização PT-BR/EN (código comentado no form fica como está)
+- Refatoração do controller `application/controllers/Home.php` (permitida apenas uma adição pontual: persistir os inputs brutos em `session->userdata('respostas')` para alimentar os exports — ver seção "Export module")
+- Test harness automatizado (sem PHPUnit/Jest configurados)
+
+## Constraints
+
+- Controller `Home.php` e lógica de cálculo dos scores **não mudam**
+- Session-based result storage (`$this->session->userdata('resultados')`) mantido
+- Tippy.js + Popper mantidos para tooltips (já em produção)
+- Todos os scores calculados hoje (STAF, BRAFIL, ASAS, CHA2DS2-VASc, C2HEST, HAVOC, CHARGE-AF, HARMS2-AF, Hamada, Mayo, HATCH, Framingham, MHS, ARIC, Suita, Taiwan-AF) continuam aparecendo
+- Lógica condicional de campos atual preservada:
+  - BMI ≥25 só aparece se "Raised BMI" = No
+  - BMI value só aparece se BMI ≥25 = Yes
+  - "Former smoker" só aparece se Smoking = No
+  - "Precordial murmur" só aparece se Significant murmur = Yes
+  - "Autoimmune disease" só aparece se Gender = female
+
+## Design decisions
+
+### 1. Visual direction — Dashboard Médico
+
+- Header escuro (`#0f172a`), cards brancos, azul clínico (`#2563eb`) como primary
+- Tipografia Inter (sans) + JetBrains Mono para valores numéricos
+- Sem ornamentos decorativos (remove `oval-shape`, `retangular-shape`, backgrounds `bg-1/2/3.jpg`)
+- Scroll global normal (remove `overflow-y: hidden` do body)
+
+### 2. Design tokens (CSS variables)
+
+```css
+:root {
+  --color-ink: #0f172a;
+  --color-ink-2: #1e293b;
+  --color-muted: #64748b;
+  --color-border: #e2e8f0;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f8fafc;
+  --color-primary: #2563eb;
+  --color-primary-dark: #1d4ed8;
+  --color-success: #16a34a;
+  --color-danger: #dc2626;
+
+  --font-sans: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-6: 24px; --space-8: 32px; --space-12: 48px;
+
+  --radius-sm: 6px;
+  --radius: 10px;
+  --radius-lg: 16px;
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow:    0 4px 12px rgba(15, 23, 42, 0.08);
+}
+```
+
+### 3. Page layouts
+
+**Home** — `home.php`
+- Container centralizado, max-width 720px, padding vertical generoso
+- Título "AFibRisk" em h1, subtítulo curto sobre o propósito
+- Botão primário "Start assessment" → `/questions`
+- Link secundário "About" → `/about`
+- Fundo `--color-surface-alt` (sem imagem)
+
+**Sobre** — `sobre.php`
+- Mesmo container centralizado max-width 720px
+- `<section>` para créditos, `<section>` destacada para disclaimer (borda esquerda `--color-danger`)
+- Título h1 "About AFibRisk"
+
+**Perguntas** — `perguntas/home.php`
+
+Layout:
+```
+┌─ Topbar sticky 56px (logo + Help + Cancel) ─────────────────┐
+├────────────────┬────────────────────────────────────────────┤
+│ Sidebar 260px  │ Conteúdo (flex)                            │
+│ (fixa desktop) │   <section id="demographic"> ...           │
+│                │   <section id="neurological"> ...          │
+│ ✓ Demographic  │   <section id="body-metrics"> ...          │
+│ ● Neurological │   <section id="history"> ...              │
+│   Body metrics │   <section id="echography"> ...           │
+│   History      │   <section id="ecg"> ...                  │
+│   Echography   │   <section id="cardiology"> ...           │
+│   ECG          │                                            │
+│   Cardiology   │   [← Previous]        [Next: Body →]       │
+│                │                                            │
+│ Progress 29%   │                                            │
+│ [Calculate]    │                                            │
+└────────────────┴────────────────────────────────────────────┘
+```
+
+Comportamento:
+- Cada seção é `<section id="...">`. Click na sidebar faz `scrollIntoView({ behavior: 'smooth' })`.
+- Sidebar usa `IntersectionObserver` com `rootMargin: "-40% 0px -55% 0px"` para marcar a seção ativa enquanto o usuário rola.
+- Item completo (`✓`): qualquer campo `name` da seção com valor preenchido → conta como "done" em verde.
+- Item ativo (`●`): azul primary. Hover de itens pendentes em cinza.
+- Barra de progresso: `(seções com ao menos 1 campo preenchido) / 7`. Atualiza ao `change` de qualquer input.
+- Radios "Yes/No" redesenhados como **pill buttons** (div com `role="radiogroup"`, cada opção um `<label>` com input escondido visualmente mas acessível por tab).
+- Inputs numéricos: `type="number"` + `inputmode="numeric"` (substitui `onkeypress="return onlyNumberKey(event)"`). Validação HTML5 `min/max` onde aplicável.
+- Tooltips de ajuda (os 5 `tippy` atuais + 12 na página de resultado): tema `customTooltipCssTema` reestilizado para a nova paleta.
+
+Mobile (≤768px):
+- Sidebar vira **drawer**: botão `☰` na topbar abre/fecha overlay 85% da largura.
+- Drawer é `<aside class="sidebar">` com `transform: translateX(-100%)` e classe `.open` que muda para `translateX(0)`.
+- Backdrop `<div class="drawer-backdrop">` com fade; click fecha drawer.
+- Botão "Calculate" sticky no rodapé (100% largura) no mobile.
+- Formulário em 1 coluna (desktop usa 2).
+
+**Resultados** — `resultado/home.php`
+
+Layout:
+```
+┌─ Topbar sticky (igual) ─────────────────────────────────────┐
+├─────────────────────────────────────────────────────────────┤
+│  h1 "Results"    Generated on 17 Apr 2026, 14:32           │
+│  [📋 Copy] [📄 PDF] [📊 CSV] [🖨 Print] [↻ New assessment]  │
+│                                                             │
+│  ┌── Card ──────────────────────────────────────────┐       │
+│  │ STAF                              6 / 8      (i) │       │
+│  │ ───────────────────────────────────              │       │
+│  │ Score of ≥5 identifies patients with AF with...  │       │
+│  └──────────────────────────────────────────────────┘       │
+│  ... (outros scores)                                        │
+│                                                             │
+│  [hidden div .pdf-template — usado pelo html2pdf]           │
+│  [modal de referências — markup existente, re-estilizado]   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Detalhes:
+- Toolbar sticky logo abaixo do título (fica visível no scroll). Desktop: ícone + label. Mobile: só ícone, com `aria-label` para acessibilidade.
+- Cards uniformes (todos brancos, `--shadow-sm`, `--radius`). Remove alternância par/ímpar.
+- Título do card: semibold, `--color-ink`. Valor: `--font-mono`, 24px, `--color-primary`, `font-variant-numeric: tabular-nums`.
+- O card exibe duas camadas de informação:
+  1. **Interpretação curta** (hoje só no tooltip Tippy de cada score, ex.: "A total score of ≥5 identifies patients with AF with sensitivity 89%..."): promovida para dentro do card abaixo do separador. Não depende mais de hover.
+  2. **Referência bibliográfica completa**: ícone `(i)` no canto superior direito do card abre o modal existente (`#referenceModal` com `.reference.<KEY>`). Markup reaproveitado, só re-estilizado.
+- Tooltips Tippy atuais nos scores ficam como **fonte da interpretação curta** — o texto vai do JS para o PHP (rendered estático no card).
+- Card do **Hamada** mantém a imagem (`assets/images/hamada/<value>.png`) com moldura `--radius` e legenda.
+- "Repeat" renomeado para "New assessment" — botão secondary no topo.
+
+Empty state (sem dados na session):
+- Texto: "No assessment yet. [Start an assessment]"
+- Botões de export desabilitados (`aria-disabled="true"`, pointer-events: none, opacity 0.5).
+
+### 4. Export module — `assets/js/export.js`
+
+Monta payload único no `DOMContentLoaded` a partir do DOM:
+
+```js
+const payload = {
+  generatedAt: "2026-04-17T14:32:00-03:00",  // ISO local
+  inputs: {  // chave = name do input, valor = value
+    age: "72", gender: "male", nihss: "8", /* ... */
+  },
+  scores: [
+    { name: "STAF",         value: "6", max: "8",  message: "..." },
+    { name: "BRAFIL",       value: "3", max: "6",  message: "..." },
+    { name: "CHA2DS2-VASc", value: "4", max: null, message: "..." },
+    // ...
+  ]
+}
+```
+
+Os inputs são injetados no `resultado/home.php` via:
+```php
+<script>window.AFIBRISK_INPUTS = <?= json_encode($this->session->userdata('respostas') ?: []) ?>;</script>
+```
+Isso **exige** que o controller `Home.php` persista os inputs brutos na sessão sob a chave `respostas` (em paralelo a `resultados`). A única alteração no controller é adicionar `$this->session->set_userdata('respostas', $this->input->post())` antes do redirect — flagged na seção de Open questions. Se o controller estiver intocável, fallback: ler os inputs do `$_POST` no próprio action e repassar via flashdata.
+
+**Copy** (texto plano):
+```
+AFibRisk — Assessment
+Generated: 2026-04-17 14:32
+
+Scores
+- STAF:          6 / 8
+- BRAFIL:        3 / 6
+- CHA2DS2-VASc:  4
+...
+
+Inputs
+- Age: 72
+- Gender: male
+- NIHSS: 8
+...
+```
+- `navigator.clipboard.writeText(text)` com try/catch
+- Fallback: `<textarea>` temporário + `document.execCommand('copy')`
+- Feedback: toast `--color-success` "Copied to clipboard" por 2s
+- Se falha em ambos: toast `--color-danger` "Couldn't copy. Try Print instead."
+
+**CSV** (research row):
+- Header: `generated_at,age,gender,nihss,...,score_staf,score_brafil,score_cha2ds2vasc,...`
+- Valores escapados: envolvidos em `"` se contêm vírgula/quebra/aspas; aspas internas viram `""`
+- UTF-8 BOM (`\uFEFF`) no início para Excel reconhecer acentos
+- Download: `Blob` + `<a download>`, filename `afibrisk-YYYY-MM-DD-HHmm.csv`
+
+**PDF** (relatório completo):
+- Biblioteca: `html2pdf.js` via CDN (`https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js`)
+- Renderiza `<div class="pdf-template" hidden>` pré-montada no view, contendo:
+  - Cabeçalho: "AFibRisk Assessment Report" + data/hora
+  - Seção "Patient inputs" — tabela 2 colunas (label, value)
+  - Seção "Scores" — um bloco por score (nome, valor, mensagem)
+  - Seção "References" — para cada score computado, a referência bibliográfica completa (reaproveita HTML de `.reference .<KEY>` do modal atual)
+  - Rodapé: disclaimer resumido + "Not a medical device"
+- Config: A4 portrait, margens 15mm, `pagebreak: { mode: ['css', 'avoid-all'] }`
+- Filename: `afibrisk-report-YYYY-MM-DD-HHmm.pdf`
+- Falha (CDN offline): toast `--color-danger` "PDF failed to generate. Try Print as a workaround."
+
+**Print** (`window.print()`):
+- CSS `@media print` em `style.css`:
+  - Esconde `.topbar`, `.toolbar`, `.btn-new`, modais
+  - Fundo branco, cores em preto
+  - Cards com borda 1px sólida em vez de shadow
+  - `break-inside: avoid` dentro de cada card
+  - Mostra data/hora e título normalmente
+
+### 5. Error handling and edge cases
+
+- **Session null/empty em `/result`** → empty state com botões desabilitados
+- **Clipboard API bloqueada** (HTTP, permissão) → fallback `execCommand`, depois toast de erro
+- **html2pdf CDN offline** → try/catch no `.save()`, toast de erro, outros botões continuam funcionais
+- **Campos numéricos vazios** → mesma validação do backend hoje; visualmente destacar primeiro campo com erro em vermelho + scroll até ele
+- **Scroll-spy com seções curtas** → `rootMargin: "-40% 0px -55% 0px"` garante uma seção ativa de cada vez
+
+### 6. Accessibility
+
+- Todos `<input>` com `<label for="...">` associado
+- Radios como pill buttons mantêm `<input type="radio">` real (visualmente escondido via `.sr-only`), acessível por tab e screen reader
+- Foco visível em todos os interativos (`outline: 2px solid var(--color-primary); outline-offset: 2px;`)
+- Toolbar ícone-only no mobile tem `aria-label` em cada botão
+- Sidebar drawer: `aria-expanded` no botão hamburger, foco transferido para primeiro item ao abrir, ESC fecha
+
+### 7. Responsive breakpoints
+
+- Desktop: ≥1024px — sidebar fixa 260px, form 2 colunas
+- Tablet: 768–1023px — sidebar fixa 220px, form 1 coluna
+- Mobile: ≤767px — sidebar drawer, topbar com hamburger, form 1 coluna, Calculate sticky
+
+### 8. Files and structure
+
+```
+plataforma/
+├── application/views/
+│   ├── header.php              [rewritten — Inter font, export.js conditional load]
+│   ├── footer.php              [rewritten — remove jQuery slim, keep Tippy/Popper]
+│   ├── home.php                [rewritten]
+│   ├── sobre.php               [rewritten]
+│   ├── perguntas/home.php      [rewritten — sidebar + sections + pill radios]
+│   └── resultado/home.php      [rewritten — toolbar, cards, pdf-template, modal re-skin]
+└── assets/
+    ├── css/style.css           [rewritten from scratch]
+    └── js/export.js            [NEW — copy, csv, pdf, print]
+```
+
+Bootstrap 5 CSS/JS removido do `header.php`. jQuery mantida (Tippy depende via Popper). Adicionado html2pdf via CDN só em `resultado/home.php`.
+
+## Verification plan
+
+Sem test harness automatizado — checklist manual obrigatório antes de merge:
+
+1. **Golden path**: home → preencher todas 7 seções → Calculate → Results → Copy → paste em editor de texto → validar formato
+2. **Lógica condicional preservada**: testar Raised BMI No → BMI ≥25 aparece; Smoking No → Former smoker aparece; Significant murmur Yes → Precordial aparece; Gender female → Autoimmune aparece
+3. **Responsivo**: testar em 1440px, 768px, 390px (Chrome DevTools device toolbar). Sidebar vira drawer abaixo de 768px
+4. **Sidebar scroll-spy**: rolar página de perguntas, confirmar que item ativo segue o scroll; clicar item, confirmar scroll suave até seção
+5. **Progresso**: preencher 1 campo em 3 seções diferentes, confirmar barra em ~43% (3/7) e checkmarks
+6. **Export CSV**: abrir em Excel + Google Sheets, validar acentos (UTF-8 BOM) e separadores
+7. **Export PDF**: abrir no Chrome PDF viewer + Adobe Reader, validar paginação das referências longas
+8. **Print preview**: Chrome + Firefox, confirmar que só título + cards + data aparecem
+9. **Acessibilidade**: tab atravessa campos na ordem lógica; foco visível; sidebar drawer fecha com ESC
+10. **Browsers**: Chrome, Firefox, Edge atuais. Safari não testado (sem ambiente) — anotar como limitação conhecida no PR
+
+## Rollout
+
+Um único PR cobrindo todas as views + CSS + JS. Preview local via XAMPP antes do merge. Screenshots das 4 telas principais (home, questions desktop, questions mobile, results) anexadas no PR.
+
+## Open questions / assumptions to validate during implementation
+
+- **Inputs na session** — confirmar na leitura do `Home.php` durante implementação se já existe persistência dos inputs brutos. Caso não, adicionar uma única linha no action `todasRespostas`: `$this->session->set_userdata('respostas', $this->input->post())` antes do redirect. Nenhuma outra mudança no controller.
+- **Validação no backend** — confirmar se o controller valida campos obrigatórios; se sim, alinhar mensagens de erro com o novo visual.
+- **Licença dos fontes** — Inter é OFL, sem problema. Confirmar que remover Multicolore Pro não quebra nada (está só no header.php).

--- a/plataforma/application/controllers/Home.php
+++ b/plataforma/application/controllers/Home.php
@@ -151,6 +151,9 @@ class Home extends CI_Controller {
 		//18. ASAS
 		$this->calculaASAS($dados);
 
+		// Persist raw inputs for exports (Copy, CSV, PDF) on the results page
+		$this->session->set_userdata('respostas', $this->input->post());
+
 		redirect('results');
 	}
 

--- a/plataforma/application/views/footer.php
+++ b/plataforma/application/views/footer.php
@@ -1,3 +1,3 @@
-<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.6.4.min.js" integrity="sha256-oP6HI9z1XaZNBrJURtCoUT5SUnxFr8s3BzRl+cbzUq8=" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@popperjs/core@2"></script>
 <script src="https://unpkg.com/tippy.js@6"></script>

--- a/plataforma/application/views/header.php
+++ b/plataforma/application/views/header.php
@@ -1,15 +1,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="iRankin">
+<meta name="description" content="AFibRisk — Atrial Fibrillation risk assessment tool">
 
 <title><?php print($titulo); ?></title>
 
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;700&display=swap" rel="stylesheet">
 
 <link rel="stylesheet" type="text/css" href="<?php echo base_url('assets/css/style.css') ?>">
 
-<link href="https://fonts.cdnfonts.com/css/multicolore-pro" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
 <script src="<?php echo base_url('assets/js/fontawsome1935e00f36.js') ?>" crossorigin="anonymous"></script>

--- a/plataforma/application/views/home.php
+++ b/plataforma/application/views/home.php
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-	<?php $this->load->view('header'); ?>
+    <?php $this->load->view('header'); ?>
 </head>
-<body id="background1">
-	<div class="container-fluid">
+<body>
+    <header class="topbar">
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk</a>
+        <nav>
+            <a href="<?php echo base_url('about'); ?>">About</a>
+        </nav>
+    </header>
 
-		<div class="d-flex flex-row-reverse bd-highlight mt-4 me-4">		
-			<a href="<?php print_r(base_url('about')) ?>" class="btn btnabout">ABOUT</a>
-		</div>		
+    <main class="home-hero">
+        <div class="eyebrow">Clinical Risk Assessment</div>
+        <h1>AFibRisk</h1>
+        <p class="lead">A research tool that aggregates 17 clinical scores for Atrial Fibrillation risk prediction from published literature.</p>
+        <div class="actions">
+            <a href="<?php echo base_url('questions'); ?>" class="btn btn-primary">Start assessment</a>
+            <a href="<?php echo base_url('about'); ?>" class="btn btn-secondary">About</a>
+        </div>
+    </main>
 
-		<div class="btnentrar centralizar-botao">			
-			<br>
-			<a href="<?php print_r(base_url('questions')) ?>" class="btn btneng">START </a>
-			<div class="oval-shape"></div>
-		</div>	
-
-	</div>
+    <?php $this->load->view('footer'); ?>
 </body>
-<footer>
-	<?php $this->load->view('footer'); ?>
-</footer>
 </html>

--- a/plataforma/application/views/perguntas/home.php
+++ b/plataforma/application/views/perguntas/home.php
@@ -314,5 +314,124 @@
     <?php echo form_close(); ?>
 
     <?php $this->load->view('footer'); ?>
+<script>
+(function () {
+    const sidebar = document.getElementById('sidebar');
+    const drawerToggle = document.getElementById('drawerToggle');
+    const drawerBackdrop = document.getElementById('drawerBackdrop');
+    const progressFill = document.getElementById('progressFill');
+    const progressPct  = document.getElementById('progressPct');
+    const form = document.getElementById('formprincipal');
+    const sectionLinks = sidebar.querySelectorAll('a[data-section]');
+    const sections = Array.from(document.querySelectorAll('.question-section'));
+
+    // ---- Drawer (mobile) ----
+    function openDrawer() {
+        sidebar.classList.add('open');
+        drawerBackdrop.classList.add('open');
+        drawerToggle.setAttribute('aria-expanded', 'true');
+    }
+    function closeDrawer() {
+        sidebar.classList.remove('open');
+        drawerBackdrop.classList.remove('open');
+        drawerToggle.setAttribute('aria-expanded', 'false');
+    }
+    drawerToggle.addEventListener('click', () => {
+        sidebar.classList.contains('open') ? closeDrawer() : openDrawer();
+    });
+    drawerBackdrop.addEventListener('click', closeDrawer);
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDrawer(); });
+    sidebar.addEventListener('click', (e) => {
+        if (e.target.closest('a[data-section]') && window.innerWidth <= 767) closeDrawer();
+    });
+
+    // ---- Scroll-spy (IntersectionObserver) ----
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                const id = entry.target.id;
+                sectionLinks.forEach(a => a.classList.toggle('active', a.dataset.section === id));
+            }
+        });
+    }, { rootMargin: '-40% 0px -55% 0px', threshold: 0 });
+    sections.forEach(s => observer.observe(s));
+
+    // ---- Smooth scroll from sidebar clicks ----
+    sectionLinks.forEach(link => {
+        link.addEventListener('click', (e) => {
+            const id = link.dataset.section;
+            const target = document.getElementById(id);
+            if (target) {
+                e.preventDefault();
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+
+    // ---- Progress + done markers ----
+    function updateProgress() {
+        let doneCount = 0;
+        sections.forEach(section => {
+            const inputs = section.querySelectorAll('input');
+            const filled = Array.from(inputs).some(inp => {
+                if (inp.type === 'radio') return inp.checked;
+                return inp.value && inp.value.trim() !== '';
+            });
+            const link = sidebar.querySelector(`a[data-section="${section.id}"]`);
+            if (link) link.classList.toggle('done', filled);
+            if (filled) doneCount++;
+        });
+        const pct = Math.round((doneCount / sections.length) * 100);
+        progressFill.style.width = pct + '%';
+        progressPct.textContent = pct + '%';
+    }
+    form.addEventListener('input', updateProgress);
+    form.addEventListener('change', updateProgress);
+    updateProgress();
+
+    // ---- Conditional fields (preserves existing behaviour) ----
+    function show(el) { if (el) el.hidden = false; }
+    function hide(el) { if (el) { el.hidden = true; el.querySelectorAll('input[type="radio"]').forEach(r => r.checked = false); el.querySelectorAll('input[type="number"], input[type="text"]').forEach(i => i.value = ''); } }
+
+    const bmi25Container = document.getElementById('bmi_25_container');
+    const bmi25Extra     = document.getElementById('additional_bmi_content');
+    const formerContainer = document.getElementById('former_smoker_container');
+    const precordialContainer = document.getElementById('precordial_murmur_container');
+    const autoimmuneContainer = document.getElementById('autoimmune_disease_container');
+
+    // Raised BMI: No → show bmi_25_container; Yes → hide both
+    document.querySelectorAll('input[name="20_raised_bmi"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'no') { show(bmi25Container); }
+        else { hide(bmi25Container); hide(bmi25Extra); }
+    }));
+    document.querySelectorAll('input[name="20_1_bmi_25"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'yes') show(bmi25Extra); else hide(bmi25Extra);
+    }));
+
+    // Smoking: No → show former smoker container
+    document.querySelectorAll('input[name="14_smoking"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'no') show(formerContainer); else hide(formerContainer);
+    }));
+
+    // Significant murmur: Yes → show precordial murmur
+    document.querySelectorAll('input[name="24_significant_murmur"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'yes') show(precordialContainer); else hide(precordialContainer);
+    }));
+
+    // Gender female → show autoimmune disease
+    document.querySelectorAll('input[name="2_gender"]').forEach(r => r.addEventListener('change', (e) => {
+        if (e.target.value === 'female') show(autoimmuneContainer); else hide(autoimmuneContainer);
+    }));
+
+    // ---- Tippy tooltips (preserves existing content) ----
+    if (window.tippy) {
+        tippy('#field_1', { content: 'Aortic, mitral, tricuspid, and/or pulmonary valve disease', theme: 'customTooltipCssTema' });
+        tippy('#field_2', { content: 'Left atrial enlargement (LAE) by ECG: p-wave duration ≥120 ms or p-wave amplitude >2.5 mm in II, or terminal p negativity in V1 (duration 0.04 s, depth 1 mm). By parasternal long-axis view, LAE = anteroposterior diameter ≥4.0 cm.', theme: 'customTooltipCssTema' });
+        tippy('#field_3', { content: 'Premature P wave (often different shape), narrow/normal QRS identical to other beats, a long pause after the PAC, normal/short/longer PR than sinus, post-extrasystolic pause.', theme: 'customTooltipCssTema' });
+        tippy('#field_4', { content: 'Premature QRS complexes unusually long (>120 ms), wide QRS, no preceding P wave, large T wave oriented opposite the major QRS deflection.', theme: 'customTooltipCssTema' });
+        tippy('#field_5', { content: 'Significant if grade ≥3/6 systolic or any diastolic murmur on auscultation.', theme: 'customTooltipCssTema' });
+    }
+})();
+</script>
 </body>
 </html>

--- a/plataforma/application/views/perguntas/home.php
+++ b/plataforma/application/views/perguntas/home.php
@@ -1,731 +1,318 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
     <?php $this->load->view('header'); ?>
 </head>
-
-<body id="background2">
-    <div class="row title">
-        <div class="col-md-12">
-            <span>Questions</span>
-        </div>
-        <div class="retangular-shape"></div>
-    </div>
-
-    <div class="container">
-
-        <div class="row" id="formquests">
-            <div class="col-md-12">
-
-                <?= form_open("home/todasRespostas", 'id="formprincipal"'); ?>
-
-                <details>
-                    <summary data-translate="demographic"><a>Demographic</a></summary>
-
-                    <p data-translate="age" class="age-input mt-3">Age
-                        <input type="text" autocomplete="off" name="1_age" maxlength="3" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="gender">Gender
-                        <label class="custom-radio">
-                            <input type="radio" name="2_gender" id="male" value="male" data-translate="male">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Male
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" name="2_gender" id="female" value="female" data-translate="female">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Female
-                        </label>
-                    </p>
-
-                    <p data-translate="white">White
-                        <label class="custom-radio">
-                            <input type="radio" name="27_white" id="white_yes" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" name="27_white" id="white_no" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="black">Black
-                        <label class="custom-radio">
-                            <input type="radio" name="28_black" id="black_yes" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" name="28_black" id="black_no" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-                </details>
-
-                <hr class="hr-personalizado">
-
-                <details>
-                    <summary data-translate="neurological"><a>Neurological</a></summary>
-
-                    <p data-translate="nihss" class="mt-3">NIH Stroke Scale on admission
-                        <input type="text" autocomplete="off" name="3_nihss" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="stroke_history">Previous Stroke or Transient Ischemic Attack
-                        <label class="custom-radio">
-                            <input type="radio" name="30_stroke" id="stroke_yes" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" name="30_stroke" id="stroke_no" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                </details>
-
-                <hr class="hr-personalizado">
-
-                <details>
-
-                    <summary data-translate="body_metrics"><a>Body metrics and laboratory</a></summary>
-
-                    <p data-translate="height" class="mt-3">Height (cm)
-                        <input type="text" autocomplete="off" name="12_height_cm" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="weight">Weight (kg)
-                        <input type="text" autocomplete="off" name="13_weight_kg" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="systolic_bp">Systolic Blood Pressure (mmHg)
-                        <input type="text" autocomplete="off" name="15_systolic_bp" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="diastolic_bp">Diastolic Blood Pressure (mmHg)
-                        <input type="text" autocomplete="off" name="16_diastolic_bp" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="raised_bmi">Raised BMI (BMI>30kg/m²)
-                        <label class="custom-radio">
-                            <input type="radio" id="raised_bmi_yes" name="20_raised_bmi" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="raised_bmi_no" name="20_raised_bmi" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <div id="bmi_25_container" style="display:none;">
-
-                        <p data-translate="bmi_25">BMI ≥25 kg/m²
-                            <label class="custom-radio">
-                                <input type="radio" id="bmi_25_yes" name="20_1_bmi_25" value="yes" data-translate="yes">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                Yes
-                            </label>
-                            <label class="custom-radio">
-                                <input type="radio" id="bmi_25_no" name="20_1_bmi_25" value="no" data-translate="no">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                No
-                            </label>
-                        </p>
-
-                        <div id="additional_bmi_content" style="display:none;">
-                            <p data-translate="bmi_value">BMI (kg/m²)
-                                <input type="text" autocomplete="off" name="20_2_bmi_value" step="0.01" onkeypress="return onlyNumberKey(event);">
-                            </p>
-                        </div>
-
-                    </div>
-
-                    <p data-translate="waist_circumference">Waist circumference (cm)
-                        <input type="text" autocomplete="off" name="34_waist_circumference" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="heart_rate">Heart rate (beats per minute)
-                        <input type="text" autocomplete="off" name="35_heart_rate" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                    <p data-translate="cholesterol_ldl">Cholesterol LDL-C (mg/dL)
-                        <input type="text" autocomplete="off" name="33_cholesterol_ldl" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                </details>
-
-                <hr class="hr-personalizado">
-
-                <details>
-
-                    <summary data-translate="personal_history"><a>Personal history</a></summary>
-
-                    <p data-translate="history_coronary_disease" class="mt-3">History of Coronary Disease
-                        <label class="custom-radio">
-                            <input type="radio" id="coronary_disease_yes" name="6_coronary_disease" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="coronary_disease_no" name="6_coronary_disease" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="history_copd">History of chronic obstructive pulmonary disease (COPD)
-                        <label class="custom-radio">
-                            <input type="radio" id="copd_yes" name="7_copd" value="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="copd_no" name="7_copd" value="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="history_hypertension">History of Arterial Hypertension
-                        <label class="custom-radio">
-                            <input type="radio" id="hypertension_yes" name="8_hypertension" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="hypertension_no" name="8_hypertension" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="history_heart_failure">History of Heart Failure
-                        <label class="custom-radio">
-                            <input type="radio" id="heart_failure_yes" name="9_heart_failure" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="heart_failure_no" name="9_heart_failure" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="history_hyperthyroidism">Known Hyperthyroidism
-                        <label class="custom-radio">
-                            <input type="radio" id="hyperthyroidism_yes" name="10_hyperthyroidism" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="hyperthyroidism_no" name="10_hyperthyroidism" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="smoking_status">Smoking
-                        <label class="custom-radio">
-                            <input type="radio" id="smoking_yes" name="14_smoking" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="smoking_no" name="14_smoking" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <div id="former_smoker_container" style="display:none;">
-
-                        <p data-translate="former_smoker">Former smoker
-                            <label class="custom-radio">
-                                <input type="radio" id="former_smoker_yes" name="14_1_former_smoker" value="yes" data-translate="yes">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                Yes
-                            </label>
-                            <label class="custom-radio">
-                                <input type="radio" id="former_smoker_no" name="14_1_former_smoker" value="no" data-translate="no">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                No
-                            </label>
-                        </p>
-
-                    </div>
-
-                    <p data-translate="history_diabetes">History of Diabetes
-                        <label class="custom-radio">
-                            <input type="radio" id="diabetes_yes" name="17_diabetes" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="diabetes_no" name="17_diabetes" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="sleep_apnea">Sleep apnea
-                        <label class="custom-radio">
-                            <input type="radio" id="sleep_apnea_yes" name="21_sleep_apnea" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="sleep_apnea_no" name="21_sleep_apnea" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="alcohol_consumption">Alcohol consumption
-                        <br>
-                        <label class="custom-radio">
-                            <input type="radio" id="alcohol_0" name="22_alcohol_consumption" value="0" data-translate="0">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            0
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="alcohol_0_7" name="22_alcohol_consumption" value="0_7" data-translate="0_7">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            0-7 std. drinks per week
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="alcohol_7_14" name="22_alcohol_consumption" value="7_14" data-translate="7_14">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            7-14 std. drinks per week
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="alcohol_15_plus" name="22_alcohol_consumption" value="15_plus" data-translate="15_plus">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            15+ std. drinks per week
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="alcohol_none" name="22_alcohol_consumption" value="none" data-translate="none">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            no consumption
-                        </label>
-                    </p>
-
-                    <p data-translate="peripheral_vascular_disease">Peripheral Vascular Disease
-                        <label class="custom-radio">
-                            <input type="radio" id="vascular_disease_yes" name="26_vascular_disease" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="vascular_disease_no" name="26_vascular_disease" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="end_stage_renal_disease">End-stage renal disease
-                        <label class="custom-radio">
-                            <input type="radio" id="renal_disease_yes" name="31_renal_disease" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="renal_disease_no" name="31_renal_disease" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                </details>
-
-                <hr class="hr-personalizado">
-
-                <details>
-
-                    <summary data-translate="echography"><a>Echography</a></summary>
-
-                    <p data-translate="left_atrium_size" class="mt-3">Left Atrium Size
-                        <input type="text" autocomplete="off" name="4_left_atrium_size" onkeypress="return onlyNumberKey(event);"> mm
-                    </p>
-
-                    <p data-translate="presence_septal_aneurysm">Presence of septal aneurysm
-                        <label class="custom-radio">
-                            <input type="radio" id="septal_aneurysm_yes" name="5_septal_aneurysm" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="septal_aneurysm_no" name="5_septal_aneurysm" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="valve_disease" id="field_1">Valve Disease
-                        <label class="custom-radio">
-                            <input type="radio" id="valve_disease_yes" name="25_valve_disease" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="valve_disease_no" name="25_valve_disease" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                </details>
-
-                <hr class="hr-personalizado">
-
-                <details>
-                    <summary data-translate="electrocardiogram"><a>Electrocardiogram</a></summary>
-
-                    <p data-translate="ecg_lv_hypertrophy" class="mt-3">Left Ventricular Hypertrophy
-                        <label class="custom-radio">
-                            <input type="radio" id="ecg_lv_hypertrophy_yes" name="18_ecg_lv_hypertrophy" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="ecg_lv_hypertrophy_no" name="18_ecg_lv_hypertrophy" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="ecg_pr_interval">PR Interval
-                        <input type="text" autocomplete="off" name="19_ecg_pr_interval"> ms
-                    </p>
-
-                    <p data-translate="left_atrial_enlargement" id="field_2">Presence of Left Atrial Enlargement
-                        <label class="custom-radio">
-                            <input type="radio" id="left_atrial_enlargement_yes" name="29_left_atrial_enlargement" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="left_atrial_enlargement_no" name="29_left_atrial_enlargement" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <br>
-
-                    <p data-translate="atrial_premature_contraction" id="field_3">Atrial premature contraction/complex
-                        <label class="custom-radio">
-                            <input type="radio" id="atrial_premature_contraction_yes" name="36_atrial_premature_contraction" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="atrial_premature_contraction_no" name="36_atrial_premature_contraction" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <br>
-
-                    <p data-translate="ventricular_premature_contraction" id="field_4">Ventricular premature contraction/complex
-                        <label class="custom-radio">
-                            <input type="radio" id="ventricular_premature_contraction_yes" name="37_ventricular_premature_contraction" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="ventricular_premature_contraction_no" name="37_ventricular_premature_contraction" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="arrhythmia">Arrhythmia (other than Atrial Fibrillation)
-                        <label class="custom-radio">
-                            <input type="radio" id="arrhythmia_yes" name="32_arrhythmia" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="arrhythmia_no" name="32_arrhythmia" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                </details>
-
-                <hr class="hr-personalizado">
-
-                <details>
-                    <summary data-translate="cardiology_general"><a>Cardiology and General</a></summary>
-
-                    <p data-translate="presence_symptomatic_stenosis" class="mt-3">Presence of symptomatic extra- or intracranial stenosis ≥50%, symptomatic arterial dissection, clinico-radiological lacunar syndrome
-                        <label class="custom-radio">
-                            <input type="radio" id="symptomatic_stenosis_yes" name="23_symptomatic_stenosis" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="symptomatic_stenosis_no" name="23_symptomatic_stenosis" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="significant_murmur" id="field_5">Significant Murmur
-                        <label class="custom-radio">
-                            <input type="radio" id="significant_murmur_yes" name="24_significant_murmur" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="significant_murmur_no" name="24_significant_murmur" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-
-                    <div id="precordial_murmur_container" style="display:none;">
-
-                        <p data-translate="presence_precordial_murmur">Presence of any precordial murmur
-                            <label class="custom-radio">
-                                <input type="radio" id="precordial_murmur_yes" name="24_1_precordial_murmur" value="yes" data-translate="yes">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                Yes
-                            </label>
-                            <label class="custom-radio">
-                                <input type="radio" id="precordial_murmur_no" name="24_1_precordial_murmur" value="no" data-translate="no">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                No
-                            </label>
-                        </p>
-
-                    </div>
-
-                    <div id="autoimmune_disease_container" style="display:none;">
-
-                        <p data-translate="autoimmune_disease">Presence of autoimmune/Inflammatory disease
-                            <label class="custom-radio">
-                                <input type="radio" id="autoimmune_disease_yes" name="38_autoimmune_disease" value="yes" data-translate="yes">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                Yes
-                            </label>
-                            <label class="custom-radio">
-                                <input type="radio" id="autoimmune_disease_no" name="38_autoimmune_disease" value="no" data-translate="no">
-                                <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                                No
-                            </label>
-                        </p>
-                    </div>
-
-                    <p data-translate="aortic_plaque">Presence of aortic plaque
-                        <label class="custom-radio">
-                            <input type="radio" id="aortic_plaque_yes" name="39_aortic_plaque" value="yes" data-translate="yes">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            Yes
-                        </label>
-                        <label class="custom-radio">
-                            <input type="radio" id="aortic_plaque_no" name="39_aortic_plaque" value="no" data-translate="no">
-                            <span class="radio-mark">(&nbsp; &nbsp; &nbsp;)</span>
-                            No
-                        </label>
-                    </p>
-
-                    <p data-translate="bnp_level">B-type natriuretic peptide (pg/ml)
-                        <input type="text" autocomplete="off" name="40_bnp_level" onkeypress="return onlyNumberKey(event);">
-                    </p>
-
-                </details>
-
-                <div class="d-flex justify-content-end mt-5" style="padding-right: 2rem;">
-                    <button type="submit" name="submit" class="btn btn-primary btn-calculate" data-translate="calculate">Calculate</button>
-                </div>
-
-
-
-                <?php echo form_close(); ?>
-
+<body>
+    <header class="topbar">
+        <button type="button" class="hamburger" id="drawerToggle" aria-label="Open sections" aria-expanded="false">&#9776;</button>
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk / Assessment</a>
+        <nav>
+            <a href="<?php echo base_url('about'); ?>">About</a>
+        </nav>
+    </header>
+
+    <div class="drawer-backdrop" id="drawerBackdrop"></div>
+
+    <?= form_open("home/todasRespostas", 'id="formprincipal"'); ?>
+    <div class="questions-shell">
+        <aside class="sidebar" id="sidebar" aria-label="Sections">
+            <h2>Sections</h2>
+            <ul>
+                <li><a href="#demographic"     data-section="demographic"><span class="marker">1</span> Demographic</a></li>
+                <li><a href="#neurological"    data-section="neurological"><span class="marker">2</span> Neurological</a></li>
+                <li><a href="#body-metrics"    data-section="body-metrics"><span class="marker">3</span> Body metrics</a></li>
+                <li><a href="#history"         data-section="history"><span class="marker">4</span> Personal history</a></li>
+                <li><a href="#echography"      data-section="echography"><span class="marker">5</span> Echography</a></li>
+                <li><a href="#ecg"             data-section="ecg"><span class="marker">6</span> Electrocardiogram</a></li>
+                <li><a href="#cardiology"      data-section="cardiology"><span class="marker">7</span> Cardiology &amp; general</a></li>
+            </ul>
+
+            <div class="progress">
+                <div class="progress-label"><span>Progress</span><span id="progressPct">0%</span></div>
+                <div class="progress-bar"><div class="progress-fill" id="progressFill"></div></div>
             </div>
+            <div class="btn-calculate-wrap">
+                <button type="submit" class="btn btn-primary">Calculate</button>
+            </div>
+        </aside>
+
+        <div class="questions-content">
+
+            <section class="question-section" id="demographic">
+                <h2>Demographic</h2>
+                <div class="field"><label for="age">Age</label>
+                    <input type="number" id="age" name="1_age" inputmode="numeric" min="0" max="120" autocomplete="off">
+                </div>
+                <div class="field"><label>Gender</label>
+                    <div class="pill-group">
+                        <input type="radio" id="gender_male" name="2_gender" value="male"><label for="gender_male">Male</label>
+                        <input type="radio" id="gender_female" name="2_gender" value="female"><label for="gender_female">Female</label>
+                    </div>
+                </div>
+                <div class="field"><label>White</label>
+                    <div class="pill-group">
+                        <input type="radio" id="white_yes" name="27_white" value="yes"><label for="white_yes">Yes</label>
+                        <input type="radio" id="white_no"  name="27_white" value="no"><label for="white_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Black</label>
+                    <div class="pill-group">
+                        <input type="radio" id="black_yes" name="28_black" value="yes"><label for="black_yes">Yes</label>
+                        <input type="radio" id="black_no"  name="28_black" value="no"><label for="black_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="neurological">
+                <h2>Neurological</h2>
+                <div class="field"><label for="nihss">NIH Stroke Scale on admission</label>
+                    <input type="number" id="nihss" name="3_nihss" inputmode="numeric" min="0" max="42" autocomplete="off">
+                </div>
+                <div class="field"><label>Previous Stroke or Transient Ischemic Attack</label>
+                    <div class="pill-group">
+                        <input type="radio" id="stroke_yes" name="30_stroke" value="yes"><label for="stroke_yes">Yes</label>
+                        <input type="radio" id="stroke_no"  name="30_stroke" value="no"><label for="stroke_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="body-metrics">
+                <h2>Body metrics and laboratory</h2>
+                <div class="field-row">
+                    <div class="field"><label for="height_cm">Height (cm)</label>
+                        <input type="number" id="height_cm" name="12_height_cm" inputmode="numeric" autocomplete="off">
+                    </div>
+                    <div class="field"><label for="weight_kg">Weight (kg)</label>
+                        <input type="number" id="weight_kg" name="13_weight_kg" inputmode="numeric" autocomplete="off">
+                    </div>
+                </div>
+                <div class="field-row">
+                    <div class="field"><label for="systolic_bp">Systolic BP (mmHg)</label>
+                        <input type="number" id="systolic_bp" name="15_systolic_bp" inputmode="numeric" autocomplete="off">
+                    </div>
+                    <div class="field"><label for="diastolic_bp">Diastolic BP (mmHg)</label>
+                        <input type="number" id="diastolic_bp" name="16_diastolic_bp" inputmode="numeric" autocomplete="off">
+                    </div>
+                </div>
+                <div class="field"><label>Raised BMI (BMI &gt; 30 kg/m²)</label>
+                    <div class="pill-group">
+                        <input type="radio" id="raised_bmi_yes" name="20_raised_bmi" value="yes"><label for="raised_bmi_yes">Yes</label>
+                        <input type="radio" id="raised_bmi_no"  name="20_raised_bmi" value="no"><label for="raised_bmi_no">No</label>
+                    </div>
+                </div>
+                <div id="bmi_25_container" hidden>
+                    <div class="field"><label>BMI ≥ 25 kg/m²</label>
+                        <div class="pill-group">
+                            <input type="radio" id="bmi_25_yes" name="20_1_bmi_25" value="yes"><label for="bmi_25_yes">Yes</label>
+                            <input type="radio" id="bmi_25_no"  name="20_1_bmi_25" value="no"><label for="bmi_25_no">No</label>
+                        </div>
+                    </div>
+                    <div id="additional_bmi_content" hidden>
+                        <div class="field"><label for="bmi_value">BMI (kg/m²)</label>
+                            <input type="number" id="bmi_value" name="20_2_bmi_value" inputmode="decimal" step="0.01" autocomplete="off">
+                        </div>
+                    </div>
+                </div>
+                <div class="field-row">
+                    <div class="field"><label for="waist">Waist circumference (cm)</label>
+                        <input type="number" id="waist" name="34_waist_circumference" inputmode="numeric" autocomplete="off">
+                    </div>
+                    <div class="field"><label for="hr">Heart rate (bpm)</label>
+                        <input type="number" id="hr" name="35_heart_rate" inputmode="numeric" autocomplete="off">
+                    </div>
+                </div>
+                <div class="field"><label for="ldl">Cholesterol LDL-C (mg/dL)</label>
+                    <input type="number" id="ldl" name="33_cholesterol_ldl" inputmode="numeric" autocomplete="off">
+                </div>
+            </section>
+
+            <section class="question-section" id="history">
+                <h2>Personal history</h2>
+                <div class="field"><label>History of Coronary Disease</label>
+                    <div class="pill-group">
+                        <input type="radio" id="coronary_yes" name="6_coronary_disease" value="yes"><label for="coronary_yes">Yes</label>
+                        <input type="radio" id="coronary_no"  name="6_coronary_disease" value="no"><label for="coronary_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>History of COPD</label>
+                    <div class="pill-group">
+                        <input type="radio" id="copd_yes" name="7_copd" value="yes"><label for="copd_yes">Yes</label>
+                        <input type="radio" id="copd_no"  name="7_copd" value="no"><label for="copd_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>History of Arterial Hypertension</label>
+                    <div class="pill-group">
+                        <input type="radio" id="htn_yes" name="8_hypertension" value="yes"><label for="htn_yes">Yes</label>
+                        <input type="radio" id="htn_no"  name="8_hypertension" value="no"><label for="htn_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>History of Heart Failure</label>
+                    <div class="pill-group">
+                        <input type="radio" id="hf_yes" name="9_heart_failure" value="yes"><label for="hf_yes">Yes</label>
+                        <input type="radio" id="hf_no"  name="9_heart_failure" value="no"><label for="hf_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Known Hyperthyroidism</label>
+                    <div class="pill-group">
+                        <input type="radio" id="hyper_yes" name="10_hyperthyroidism" value="yes"><label for="hyper_yes">Yes</label>
+                        <input type="radio" id="hyper_no"  name="10_hyperthyroidism" value="no"><label for="hyper_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Smoking</label>
+                    <div class="pill-group">
+                        <input type="radio" id="smoking_yes" name="14_smoking" value="yes"><label for="smoking_yes">Yes</label>
+                        <input type="radio" id="smoking_no"  name="14_smoking" value="no"><label for="smoking_no">No</label>
+                    </div>
+                </div>
+                <div id="former_smoker_container" hidden>
+                    <div class="field"><label>Former smoker</label>
+                        <div class="pill-group">
+                            <input type="radio" id="former_yes" name="14_1_former_smoker" value="yes"><label for="former_yes">Yes</label>
+                            <input type="radio" id="former_no"  name="14_1_former_smoker" value="no"><label for="former_no">No</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="field"><label>History of Diabetes</label>
+                    <div class="pill-group">
+                        <input type="radio" id="dm_yes" name="17_diabetes" value="yes"><label for="dm_yes">Yes</label>
+                        <input type="radio" id="dm_no"  name="17_diabetes" value="no"><label for="dm_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Sleep apnea</label>
+                    <div class="pill-group">
+                        <input type="radio" id="sleep_yes" name="21_sleep_apnea" value="yes"><label for="sleep_yes">Yes</label>
+                        <input type="radio" id="sleep_no"  name="21_sleep_apnea" value="no"><label for="sleep_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Alcohol consumption</label>
+                    <div class="pill-group">
+                        <input type="radio" id="alc_0"    name="22_alcohol_consumption" value="0"><label for="alc_0">0</label>
+                        <input type="radio" id="alc_0_7"  name="22_alcohol_consumption" value="0_7"><label for="alc_0_7">0–7 / week</label>
+                        <input type="radio" id="alc_7_14" name="22_alcohol_consumption" value="7_14"><label for="alc_7_14">7–14 / week</label>
+                        <input type="radio" id="alc_15"   name="22_alcohol_consumption" value="15_plus"><label for="alc_15">15+ / week</label>
+                        <input type="radio" id="alc_none" name="22_alcohol_consumption" value="none"><label for="alc_none">None</label>
+                    </div>
+                </div>
+                <div class="field"><label>Peripheral Vascular Disease</label>
+                    <div class="pill-group">
+                        <input type="radio" id="pvd_yes" name="26_vascular_disease" value="yes"><label for="pvd_yes">Yes</label>
+                        <input type="radio" id="pvd_no"  name="26_vascular_disease" value="no"><label for="pvd_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>End-stage renal disease</label>
+                    <div class="pill-group">
+                        <input type="radio" id="renal_yes" name="31_renal_disease" value="yes"><label for="renal_yes">Yes</label>
+                        <input type="radio" id="renal_no"  name="31_renal_disease" value="no"><label for="renal_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="echography">
+                <h2>Echography</h2>
+                <div class="field"><label for="la_size">Left Atrium Size (mm)</label>
+                    <input type="number" id="la_size" name="4_left_atrium_size" inputmode="numeric" autocomplete="off">
+                </div>
+                <div class="field"><label>Presence of septal aneurysm</label>
+                    <div class="pill-group">
+                        <input type="radio" id="septal_yes" name="5_septal_aneurysm" value="yes"><label for="septal_yes">Yes</label>
+                        <input type="radio" id="septal_no"  name="5_septal_aneurysm" value="no"><label for="septal_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_1">Valve Disease <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="valve_yes" name="25_valve_disease" value="yes"><label for="valve_yes">Yes</label>
+                        <input type="radio" id="valve_no"  name="25_valve_disease" value="no"><label for="valve_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="ecg">
+                <h2>Electrocardiogram</h2>
+                <div class="field"><label>Left Ventricular Hypertrophy</label>
+                    <div class="pill-group">
+                        <input type="radio" id="lvh_yes" name="18_ecg_lv_hypertrophy" value="yes"><label for="lvh_yes">Yes</label>
+                        <input type="radio" id="lvh_no"  name="18_ecg_lv_hypertrophy" value="no"><label for="lvh_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label for="pr">PR Interval (ms)</label>
+                    <input type="number" id="pr" name="19_ecg_pr_interval" inputmode="numeric" autocomplete="off">
+                </div>
+                <div class="field"><label id="field_2">Presence of Left Atrial Enlargement <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="lae_yes" name="29_left_atrial_enlargement" value="yes"><label for="lae_yes">Yes</label>
+                        <input type="radio" id="lae_no"  name="29_left_atrial_enlargement" value="no"><label for="lae_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_3">Atrial premature contraction/complex <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="apc_yes" name="36_atrial_premature_contraction" value="yes"><label for="apc_yes">Yes</label>
+                        <input type="radio" id="apc_no"  name="36_atrial_premature_contraction" value="no"><label for="apc_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_4">Ventricular premature contraction/complex <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="vpc_yes" name="37_ventricular_premature_contraction" value="yes"><label for="vpc_yes">Yes</label>
+                        <input type="radio" id="vpc_no"  name="37_ventricular_premature_contraction" value="no"><label for="vpc_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label>Arrhythmia (other than AF)</label>
+                    <div class="pill-group">
+                        <input type="radio" id="arr_yes" name="32_arrhythmia" value="yes"><label for="arr_yes">Yes</label>
+                        <input type="radio" id="arr_no"  name="32_arrhythmia" value="no"><label for="arr_no">No</label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="question-section" id="cardiology">
+                <h2>Cardiology and general</h2>
+                <div class="field"><label>Presence of symptomatic extra- or intracranial stenosis &#x2265;50%, symptomatic arterial dissection, or clinico-radiological lacunar syndrome</label>
+                    <div class="pill-group">
+                        <input type="radio" id="sten_yes" name="23_symptomatic_stenosis" value="yes"><label for="sten_yes">Yes</label>
+                        <input type="radio" id="sten_no"  name="23_symptomatic_stenosis" value="no"><label for="sten_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label id="field_5">Significant Murmur <span class="tooltip-trigger">i</span></label>
+                    <div class="pill-group">
+                        <input type="radio" id="murmur_yes" name="24_significant_murmur" value="yes"><label for="murmur_yes">Yes</label>
+                        <input type="radio" id="murmur_no"  name="24_significant_murmur" value="no"><label for="murmur_no">No</label>
+                    </div>
+                </div>
+                <div id="precordial_murmur_container" hidden>
+                    <div class="field"><label>Presence of any precordial murmur</label>
+                        <div class="pill-group">
+                            <input type="radio" id="prec_yes" name="24_1_precordial_murmur" value="yes"><label for="prec_yes">Yes</label>
+                            <input type="radio" id="prec_no"  name="24_1_precordial_murmur" value="no"><label for="prec_no">No</label>
+                        </div>
+                    </div>
+                </div>
+                <div id="autoimmune_disease_container" hidden>
+                    <div class="field"><label>Presence of autoimmune / inflammatory disease</label>
+                        <div class="pill-group">
+                            <input type="radio" id="auto_yes" name="38_autoimmune_disease" value="yes"><label for="auto_yes">Yes</label>
+                            <input type="radio" id="auto_no"  name="38_autoimmune_disease" value="no"><label for="auto_no">No</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="field"><label>Presence of aortic plaque</label>
+                    <div class="pill-group">
+                        <input type="radio" id="aortic_yes" name="39_aortic_plaque" value="yes"><label for="aortic_yes">Yes</label>
+                        <input type="radio" id="aortic_no"  name="39_aortic_plaque" value="no"><label for="aortic_no">No</label>
+                    </div>
+                </div>
+                <div class="field"><label for="bnp">B-type natriuretic peptide (pg/ml)</label>
+                    <input type="number" id="bnp" name="40_bnp_level" inputmode="numeric" autocomplete="off">
+                </div>
+            </section>
+
         </div>
     </div>
-</body>
-<footer>
+
+    <div class="mobile-submit">
+        <button type="submit" class="btn btn-primary">Calculate</button>
+    </div>
+    <?php echo form_close(); ?>
 
     <?php $this->load->view('footer'); ?>
-
-</footer>
-
-<script>
-    tippy('#field_1', {
-        content: 'Aortic, mitral, tricuspid, and/or pulmonary valve disease',
-        theme: 'customTooltipCssTema',
-        arrow: false,
-    });
-
-    tippy('#field_2', {
-        content: 'Left atrial enlargement (LAE) by ECG was defined as a p-wave duration of ≥ 120 ms or p wave amplitude >2.5 mm in II and/or terminal p negativity in V1 duration 0.04 s, depth 1 mm.<br>When from the bidimensional parasternal (as adopted by the ASAS score) long-axis view, LAE may be defined as an anteroposterior diameter ≥4.0cm',
-        theme: 'customTooltipCssTema',
-        arrow: false,
-    });
-
-    tippy('#field_3', {
-        content: 'An atrial premature contraction (PAC) is an extra heartbeat that starts in the upper chambers of the heart. On an ECG, PACs can appear as: - A premature P wave, which is usually a different shape than the other P waves - A narrow or normal QRS complex, which is identical to the other normal beats - A long pause after the PAC as the heart tries to restore its normal rhythm - A normal, short, or longer PR interval than sinus rhythm - Post-extrasystolic pause',
-        theme: 'customTooltipCssTema',
-        arrow: false,
-    });
-
-    tippy('#field_4', {
-        content: 'Premature Ventricular Contrations are characterized by: - Premature QRS complexes that are unusually long (typically >120 msec) - Wide QRS complexes on the ECG - Complexes that are not preceded by a P wave - A large T wave that is oriented in a direction opposite the major deflection of the QRS ',
-        theme: 'customTooltipCssTema',
-        arrow: false,
-    });
-
-    tippy('#field_5', {
-        content: 'A significant cardiac murmur was considered present if grade ≥3 out of 6 systolic or any diastolic murmur was auscultated by the physician',
-        theme: 'customTooltipCssTema',
-        arrow: false,
-    });
-
-    function onlyNumberKey(evt) {
-        var ASCIICode = (evt.which) ? evt.which : evt.keyCode;
-        if (ASCIICode > 31 && (ASCIICode < 48 || ASCIICode > 57) && ASCIICode != 44)
-            return false;
-        return true;
-    }
-
-    document.addEventListener("DOMContentLoaded", function() {
-        // Get the gender radio buttons
-        var genderRadios = document.querySelectorAll('input[name="2_gender"]');
-
-        // Add change event listeners to the gender radio buttons
-        genderRadios.forEach(function(radio) {
-            radio.addEventListener('change', function() {
-                // Determine whether the "female" radio button is checked
-                var isFemale = document.querySelector('input[name="2_gender"][value="female"]').checked;
-
-                // Get the autoimmune disease question container
-                var autoimmuneDiseaseContainer = document.getElementById('autoimmune_disease_container');
-
-                // Show or hide the autoimmune disease question based on the gender selection
-                autoimmuneDiseaseContainer.style.display = isFemale ? 'block' : 'none';
-            });
-        });
-    });
-
-    document.getElementById('raised_bmi_yes').addEventListener('change', function() {
-
-        document.getElementById('bmi_25_container').style.display = 'none';
-        document.getElementById('additional_bmi_content').style.display = 'none';
-
-        clearRadioSelection('20_1_bmi_25');
-
-        const bmiValueInput = document.querySelector('input[name="20_2_bmi_value"]');
-        if (bmiValueInput) {
-            bmiValueInput.value = '';
-        }
-    });
-
-    document.getElementById('raised_bmi_no').addEventListener('change', function() {
-        document.getElementById('bmi_25_container').style.display = 'block';
-
-    });
-
-    document.getElementById('bmi_25_yes').addEventListener('change', function() {
-        document.getElementById('additional_bmi_content').style.display = 'block';
-
-    });
-    document.getElementById('bmi_25_no').addEventListener('change', function() {
-        document.getElementById('additional_bmi_content').style.display = 'none';
-        const bmiValueInput = document.querySelector('input[name="20_2_bmi_value"]');
-        if (bmiValueInput) {
-            bmiValueInput.value = '';
-        }
-    });
-
-    if (document.getElementById('raised_bmi_yes').checked) {
-        document.getElementById('bmi_25_container').style.display = 'block';
-    }
-    if (document.getElementById('bmi_25_yes').checked) {
-        document.getElementById('additional_bmi_content').style.display = 'block';
-    }
-
-    document.getElementById('smoking_yes').addEventListener('change', function() {
-        document.getElementById('former_smoker_container').style.display = 'none';
-        clearRadioSelection('14_1_former_smoker');
-    });
-
-    document.getElementById('smoking_no').addEventListener('change', function() {
-        document.getElementById('former_smoker_container').style.display = 'block';
-    });    
-
-    document.querySelectorAll('input[name="24_significant_murmur"]').forEach(radio => {
-        radio.addEventListener('change', function() {
-            // If 'Yes' is selected for Significant Murmur, show the next question, else hide and clear it
-            const displayStyle = radio.value === 'yes' ? 'block' : 'none';
-            document.getElementById('precordial_murmur_container').style.display = displayStyle;
-            if (radio.value === 'no') {
-                clearRadioSelection('24_1_precordial_murmur');
-            }
-        });
-    });
-
-    function clearRadioSelection(radioName) {
-        document.querySelectorAll(`input[name="${radioName}"]`).forEach(radio => {
-            radio.checked = false;
-        });
-    }
-
-    // // Sample translations
-    // const translations = {
-    //   'pt-br': {
-    //     demographic: "Demográfico",
-    //     age: "Idade:",
-    //     gender: "Gênero:",
-    //     male: "Masculino",
-    //     female: "Feminino",
-    //     neurological: "Neurológico",
-    //     nihss: "Escala de AVC NIH na admissão:",
-    //     stroke_history: "Acidente Vascular Cerebral prévio ou Ataque Isquêmico Transitório:",
-    //     yes: "Sim",
-    //     no: "Não"
-    //     // ... more translations
-    //   },
-    //   // ... other languages
-    // };
-
-    // function translate(lang) {
-    //   document.querySelectorAll('[data-translate]').forEach((elem) => {
-    //     const key = elem.getAttribute('data-translate');
-    //     const translation = translations[lang][key];
-    //     if (translation) {
-    //       if (elem.tagName === 'INPUT' && elem.type === 'radio') {
-    //         elem.nextSibling.textContent = translation;
-    //       } else {
-    //         elem.textContent = translation;
-    //       }
-    //     }
-    //   });
-    // }
-
-    // // Event listener for language change
-    // document.getElementById('languageSelect').addEventListener('change', function() {
-    //   translate(this.value);
-    // });
-
-    // // Set initial language based on browser preference or default to English
-    // translate(navigator.language.toLowerCase() === 'pt-br' ? 'pt-br' : 'en');
-</script>
-
+</body>
 </html>

--- a/plataforma/application/views/perguntas/home.php
+++ b/plataforma/application/views/perguntas/home.php
@@ -330,6 +330,8 @@
         sidebar.classList.add('open');
         drawerBackdrop.classList.add('open');
         drawerToggle.setAttribute('aria-expanded', 'true');
+        const firstLink = sidebar.querySelector('a[data-section]');
+        if (firstLink) firstLink.focus();
     }
     function closeDrawer() {
         sidebar.classList.remove('open');

--- a/plataforma/application/views/resultado/home.php
+++ b/plataforma/application/views/resultado/home.php
@@ -1,400 +1,254 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-	<?php $this->load->view('header'); ?>
+    <?php $this->load->view('header'); ?>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha512-GsLlZN/3F2ErC5ifS5QtgpiJtWd43JWSuIgh7mbzZ8zBps+dvLusV+eNQATqgA/HdeKFVgA5v3S/cIrLF7QnIg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
-<body id="background3">
+<body>
+    <header class="topbar">
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk</a>
+        <nav>
+            <a href="<?php echo base_url('about'); ?>">About</a>
+        </nav>
+    </header>
 
-    <div class="row title results">
-        <div class="col-md-12">
-            <span>Results</span>
-        </div>
-        <div class="retangular-shape"></div>
-    </div>
+    <main class="results-shell">
+        <?php
+            $resultado = $this->session->userdata('resultados');
+            $respostas = $this->session->userdata('respostas') ?: array();
+            $hasResults = is_array($resultado) && count($resultado) > 0;
+        ?>
 
-	<div class="container container-resultado">
+        <?php if (!$hasResults): ?>
+            <div class="empty-state">
+                <h2>No assessment yet</h2>
+                <p>Fill out the questionnaire to see results here.</p>
+                <a href="<?php echo base_url('questions'); ?>" class="btn btn-primary">Start an assessment</a>
+            </div>
+        <?php else: ?>
+            <div class="results-header">
+                <h1>Results</h1>
+                <div class="timestamp" id="generatedAt"></div>
+            </div>
 
-        <div class="subcontainer-resultado">
+            <div class="toolbar" role="toolbar" aria-label="Export results">
+                <button type="button" class="btn btn-secondary" data-action="copy"  aria-label="Copy to clipboard">📋 <span class="btn-label">Copy</span></button>
+                <button type="button" class="btn btn-secondary" data-action="pdf"   aria-label="Download PDF">📄 <span class="btn-label">PDF</span></button>
+                <button type="button" class="btn btn-secondary" data-action="csv"   aria-label="Download CSV">📊 <span class="btn-label">CSV</span></button>
+                <button type="button" class="btn btn-secondary" data-action="print" aria-label="Print">🖨 <span class="btn-label">Print</span></button>
+                <a href="<?php echo base_url('questions'); ?>" class="btn btn-ghost" style="margin-left:auto">↻ New assessment</a>
+            </div>
 
-            <?php 
-                $resultado = $this->session->userdata('resultados'); 
-
-                if($resultado != null){
-                    foreach ($resultado as $key => $value) {
-                        if ($value['resposta'] != 'none') {
-                            echo '<div class="card-container">';
-                            echo '<div class="card">';
-                            echo '<div class="card-header">';
-                            echo '<h5 class="card-title">'.$key.'</h5>';
-                            if ($value['message']) {
-                                $id = str_replace(' ', '', $key);
-                                if (strpos($key, 'BRAFIL') !== false) {
-                                    $id = 'BRAFIL';
-                                }
-                                echo '<i class="fas fa-info-circle show-reference" id="'.$id.'"></i>'; 
-                            }
-                            echo '</div>';
-                            echo '<div class="card-body">';    
-                            if ($key == 'Hamada') {
-                                echo '<img src="'.base_url("assets/images/hamada/".$value['resposta'].".png").'" class="img-size" alt="Hamada">';                             
-                            } else{
-                                echo '<p class="card-text">'.$value['resposta'].'</p>'; 
-                            }                          
-                            echo '</div>';
-                            echo '</div>';
-                            echo '</div>';
-                        }
-                    }
-                }            
-            ?>
-
-            <div class="d-flex justify-content-end mt-5 div-btn-calculate">
-                <button type="button" name="submit" class="btn btn-primary btn-calculate" data-translate="repeat">Repeat</button>
-            </div>   
-            
-            <!-- Modal -->
-            <div class="modal fade" id="referenceModal" tabindex="-1" role="dialog" aria-labelledby="referenceModalLabel" aria-hidden="true">
-                <div class="modal-dialog modal-lg"" role="document">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="referenceModalLabel">Reference</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            <div id="resultCards">
+                <?php foreach ($resultado as $key => $value):
+                    if ($value['resposta'] === 'none') continue;
+                    $id = str_replace(' ', '', $key);
+                    if (strpos($key, 'BRAFIL') !== false) $id = 'BRAFIL';
+                ?>
+                    <div class="result-card" data-score-name="<?= htmlspecialchars($key) ?>" data-score-value="<?= htmlspecialchars($value['resposta']) ?>">
+                        <div class="card-head">
+                            <h3><?= htmlspecialchars($key) ?></h3>
+                            <?php if ($key === 'Hamada'): ?>
+                                <span class="value">see chart</span>
+                            <?php else: ?>
+                                <span class="value"><?= htmlspecialchars($value['resposta']) ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($value['message'])): ?>
+                                <button type="button" class="ref-btn show-reference" data-ref="<?= $id ?>" aria-label="View reference"><i class="fas fa-info-circle"></i></button>
+                            <?php endif; ?>
                         </div>
-                        <div class="modal-body">
-                            <div class="reference STAF">
-                                <p><b>Score for the Targeting of Atrial Fibrillation (STAF) - A New Approach to the Detection of Atrial Fibrillation in the Secondary Prevention of Ischemic Stroke</b></p>
-                                <p>Laurent Suissa, MD; David Bertora, MD; Sylvain Lachaud, MD; Marie He´le`ne Mahagne, MD, PhD</p>
-                                <p>Background and Purpose—The high risk of recurrence and comorbidity after a stroke associated with atrial fibrillation (AF) justifies an aggressive diagnostic approach so that anticoagulant treatment can be initiated. <br>
-                                    Methods—The clinical and paraclinical characteristics of consecutive ischemic stroke patients with and without documented AF were recorded. Independent predictive factors were then used to produce a predictive grading score for diagnosing AF, derived by logistic regression analysis: Score for the Targeting of Atrial Fibrillation (STAF). <br>
-                                    Results—STAF, calculated from the sum of the points for the 4 items (possible total score 0 to 8): age _62 years (2 points); NIHSS _8 (1 point); left atrial dilatation (2 points); absence of symptomatic intra or extracranial stenosis _50%, or clinico-radiological lacunar syndrome (3 points). STAF _5 identified patients with AF with a sensitivity of 89% and a specificity of 88%. <br>
-                                    Conclusions—STAF can be used as part of a novel and simple strategy for the targeting of AF in the secondary prevention of ischemic stroke. A multicenter study is now required to validate STAF in a larger number of patients
-                                    </p>
-                                <p><b>DOI: 10.1161/STROKEAHA.109.552679</b></p>
-                            </div>
+                        <?php if ($key === 'Hamada'): ?>
+                            <img class="hamada-image" src="<?= base_url('assets/images/hamada/' . $value['resposta'] . '.png') ?>" alt="Hamada risk chart">
+                        <?php endif; ?>
+                        <?php if (!empty($value['interpretation'])): ?>
+                            <p class="interp"><?= htmlspecialchars($value['interpretation']) ?></p>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
 
+            <!-- Inputs payload for export.js -->
+            <script>
+                window.AFIBRISK_INPUTS = <?= json_encode($respostas, JSON_UNESCAPED_UNICODE) ?>;
+            </script>
 
-                            <div class="reference BRAFIL">
-                                <p><b>A predictive score of Atrial Fibrillation in post-stroke patients</b></p>
-                                <p>Caroliny Trevisan Teixeira, Vanessa Rizelio, Alexandre Robles, Levi Coelho Maia Barros, Gisele Sampaio Silva, Joao Brainer Clares de Andrade</p>
-                                <p>Background and objective <br>
-                                    Atrial Fibrillation (AF) is a risk factor for cerebral ischemia. Identifying the presence of AF, especially in paroxysmal cases, may take time and lacks clear support in the literature regarding the optimal investigative approach; in resource-limited settings, identifying a higher-risk group for AF can assist in planning further investigation. Our objective is to develop a scoring tool to predict the risk of AF in the post-stroke follow-up. <br>
-                                    Methods <br>
-                                    A retrospective longitudinal study with data collected from electronic medical records of patients hospitalized and followed up for cerebral ischemia from 2014 to 2021 at a tertiary stroke center. Demographic, clinical, laboratory, electrocardiogram, and echocardiogram data, as well as neuroimaging, were collected. A stepwise logistic regression was employed to identify associated variables. A score with integer numbers was created based on beta-coefficients. Calibration and validation were performed to evaluate accuracy. <br>
-                                    Results <br>
-                                    We included 872 patients in our final analysis. The score was created with left atrial diameter ≥42 mm (2 points), age ≥70 years (1), presence of septal aneurysm (2), and NIHSS ≥6 at admission (1). The score ranges from 0 to 6. Patients with a score ≥2 points had a fivefold increased risk of detecting AF in the follow-up. The area under the curve (AUC) was 0.77 (0.72-0.85). <br>
-                                    Conclusions <br>
-                                    It was possible to structure an accurate risk score tool for AF, which could be validated in multicenter samples in future studies
-                                </p>
-                            </div>
+            <!-- Offscreen PDF template: export.js fills `#pdfBody` on demand -->
+            <div class="pdf-template" id="pdfTemplate" aria-hidden="true">
+                <h1>AFibRisk — Assessment Report</h1>
+                <div id="pdfBody"></div>
+                <footer>
+                    Not a medical device. This report is for educational/research use only.
+                    See the About page for the full disclaimer.
+                </footer>
+            </div>
 
-                            <div class="reference TheHeinzNixdorfRecallStudy">
-                                <p><b>B-type natriuretic peptide for incident atrial fibrillation-The Heinz Nixdorf Recall Study</b></p>
-                                <p>Kaffer Kara , Marie Henrike Geisel , Stefan Möhlenkamp , Nils Lehmann , Hagen Kälsch , Marcus Bauer , Till Neumann , Nico Dragano , Susanne Moebus , Karl-Heinz Jöckel , Raimund Erbel , Amir Abbas Mahabadi </p>
-                                <p>Abstract <br>
-                                    Background: Atrial fibrillation (AF) is the most common arrhythmia and is associated with increased morbidity and mortality. Thus, identifying subjects with unknown AF or at higher risk for future AF in the general population is of importance. B-type natriuretic peptide (BNP) is linked with silent cardiac diseases. We evaluated the association of BNP with incident AF in a large population-based cohort study. <br>
-                                    Methods: We included subjects from the population-based Heinz Nixdorf Recall study without known coronary heart disease, prior stroke, history of open heart surgery, heart-device therapy, or prevalent AF at baseline. Association of continuous and binary (≥31pg/ml for male, ≥45pg/ml for female) BNP with incident AF after 5 years was assessed using logistic regression analysis. <br>
-                                    Results: A total of 3067 subjects (mean age 58.9 years, 47.9% male) were included in this analysis. Subjects with incident AF (n=42) had higher levels of BNP (median (Q1; Q3): 33.2pg/ml (19.4; 50.5) vs. 16.9pg/ml (9.2; 30.2)). Likewise, BNP was associated with incidence of AF both in univariate model and when adjusting for AF risk factors (odds ratio (OR) (95% confidence interval (CI)): BNP as continuous variable: 1.27 (1.09; 1.47), p=0.002; BNP as binary variable: 2.68 (1.41; 5.11) with AF risk factor adjustment). Notably, especially younger subjects (<60 years) showed stronger association with incident AF than older ones (OR (95%CI) for dichotomized BNP: 7.20 (1.60; 32.49), p=0.01 for <60 years, vs. 2.13 (0.89; 5.09), p=0.09 for 60-70 years, and 4.40 (1.29; 14.97), p=0.02 for >70 years).
-                                </p>
-                                <p>Conclusions: Elevated levels of BNP are associated with significant excess of incident AF, independent of traditional AF risk factors in the general population. Gender-specific BNP thresholds may help in prevention by detecting unknown or future AF, which carries a high risk of stroke events.</p>
-                                <p><b>doi: 10.1016/j.jjcc.2014.08.003</b></p>
-                            </div>
-
-                            <div class="reference ASAS">
-                                <p><b>Score for atrial fibrillation detection in acute stroke and transient ischemic attack patients in a Brazilian population: The acute stroke atrial fibrillation scoring system</b></p>
-                                <p>Marcelo Marinho de Figueiredo, Ana Clara Tude Rodrigues, Monique Bueno Alves, Miguel Cendoroglo Neto, Gisele Sampaio Silva</p>
-                                <p>OBJECTIVE: Atrial fibrillation is a common arrhythmia that increases the risk of stroke by four- to five-fold. We aimed to establish a profile of patients with atrial fibrillation from a population of patients admitted with acute ischemic stroke or transient ischemic attack using clinical and echocardiographic findings. <br>
-                                    METHODS: We evaluated patients consecutively admitted to a tertiary hospital with acute ischemic stroke or transient ischemic attack. Subjects were divided into an original set (admissions from May 2009 to October 2010) and a validation set (admissions from November 2010 to April 2013). The study was designed as a cohort, with clinical and echocardiographic findings compared between patients with and without atrial fibrillation. A multivariable model was built, and independent predictive factors were used to produce a predictive grading score for atrial fibrillation (Acute Stroke AF Score-ASAS). <br>
-                                    RESULTS: A total of 257 patients were evaluated from May 2009 to October 2010 and included in the original set. Atrial fibrillation was diagnosed in 17.5% of these patients. Significant predictors of atrial fibrillation in the multivariate analysis included age, National Institutes of Health Stroke Scores, and the presence of left atrial enlargement. These predictors were used in the final logistic model. For this model, the area under the receiver operating characteristic curve was 0.79. The score derived from the logistic regression analysis was -- <br>
-                                    The model developed from the original data set was then applied to the validation data set, showing the preserved discriminatory ability of the model (c statistic = 0.76). <br>
-                                    CONCLUSIONS: Our risk score suggests that the individual risk for atrial fibrillation in patients with acute ischemic stroke can be assessed using simple data, including age, National Institutes of Health Stroke Scores at
-                                    admission, and the presence of left atrial enlargement.
-                                    DOI: 10.6061/clinics/2014(04)04
-                                </p>
-                            </div>
-
-                            <div class="reference CHA2DS2-VASC">
-                                <p><b>Usefulness of CHADS2 and CHA2DS2-VASc Scores in the Prediction of New-Onset Atrial Fibrillation: A Population-Based Study</b></p>
-                                <p>Walid Saliba , Naomi Gronich , Ofra Barnett-Griness , Gad Rennert </p>
-                                <p>Abstract <br>
-                                    Background: CHADS2 and CHA2DS2-VASc are validated scores used to predict stroke in patients with atrial fibrillation. Many of the individual risk factors included in these scores are also risk factors for atrial fibrillation. We aimed to examine the performance of CHADS2 and CHA2DS2-VASc scores in predicting new-onset atrial fibrillation in subjects without preexisting diagnosis of atrial fibrillation.
-                                </p>
-                                <p>Methods: Using the computerized database of the largest health maintenance organization in Israel, we identified all adults aged 50 years or older without atrial fibrillation prior to January 1, 2012. CHADS2 and CHA2DS2-VASc scores were calculated for each participant at study entry, and the cohort was followed for incident atrial fibrillation until December 31, 2014.</p>
-                                <p>Results: Of 1,062,073 subjects without preexisting diagnosis of atrial fibrillation; 23,223 developed atrial fibrillation during a follow-up of 3,053,754 person-years (incidence rate, 0.76 per 100 person-years). Incidence rate of atrial fibrillation increased in a graded manner with increasing CHA2DS2-VASc score: 0.17, 0.21, 0.49, 0.94, 1.65, 2.31, 2.75, 3.39, 4.09, and 6.71 per 100 person-years for CHA2DS2-VASc score of 0 to 9 points, respectively (P < .001). The hazard ratio for atrial fibrillation for each 1-point increase in CHA2DS2-VASc score was 1.57 (95% confidence interval [CI], 1.56-1.58). Results were similar for CHADS2 score. The area under the receiver operating characteristic curve to predict new-onset atrial fibrillation was 0.728 (95% CI, 0.725-0.711) and 0.744 (95% CI, 0.741-0.747) for CHADS2 and CHA2DS2-VASc scores, respectively.</p>
-                                <p>Conclusions: CHADS2 and CHA2DS2-VASc scores are directly associated with the incidence of new-onset atrial fibrillation, and have a relatively high performance for atrial fibrillation prediction.</p>
-                                <p><b>PMID: 27012854 DOI: 10.1016/j.amjmed.2016.02.029</b></p>
-                            </div>
-
-                            <div class="reference C2HEST">
-                                <p><b>C2HEST score for atrial fibrillation risk prediction models: a Diagnostic Accuracy Tests meta-analysis</b></p>
-                                <p>Habib Haybar , Kimia Shirbandi , Fakher Rahim </p>
-                                <p>Abstract <br>
-                                    Background: This meta-analysis aimed to assess the value of the C2HEST score to facilitate population screening and detection of AF risk in millions of populations and validate risk scores and their composition and discriminatory power for identifying people at high or low risk of AF. We searched major indexing databases, including Pubmed/Medline, ISI web of science, Scopus, Embase, and Cochrane central, using ("C2HEST" OR "risk scoring system" OR "risk score") AND ("atrial fibrillation (AF)" OR "atrial flutter" OR "tachycardia, supraventricular" OR "heart atrium flutter") without any language, study region or study type restrictions between 1990 and 2021 years. Analyses were done using Meta-DiSc. The title and abstract screening were conducted by two independent investigators.
-                                </p>
-                                <p>Results: Totally 679 records were found through the initial search, of which ultimately, nine articles were included in the qualitative and quantitative analyses. The risk of AF accompanied every one-point increase of C2HEST score (OR 1.03, 95% CI 1.01-1.05, p < 0.00001), with a high heterogeneity across studies (I2 = 100%). The SROC for C2HEST score in the prediction of AF showed that the overall area under the curve (AUC) was 0.91 (95% CI 0.85-0.96), AUC in Asian population was 0.87 (95% CI: 0.78-0.95) versus non-Asian 0.95 (95% CI 0.91-0.99), and in general population was 0.92 (95% CI 0.85-0.99) versus those with chronic conditions 0.83 (95% CI 0.71-0.95), respectively</p>
-                                <p>Conclusions: The results of this research support the idea that this quick score has the opportunity for use as a risk assessment in patients' AF screening strategies.</p>
-                                <p><b>PMID: 34862957 PMCID: PMC8643379 DOI: 10.1186/s43044-021-00230-0</b></p>
-                            </div>
-
-                            <div class="reference Takase">
-                                <p><b>Prediction of Atrial Fibrillation by B-type Natriuretic Peptide</b></p>
-                                <p>Hiroyuki Takase, MD, Yasuaki Dohi, MD, Hiroo Sonoda, MD, and Genjiro Kimura, MD</p>
-                                <p>Background: Although several conditions have been proposed as risk factors contributing to the incidence of atrial fibrillation, many individuals without such ‘risk factors’ also suffer from atrial fibrillation. The present study tested the hypothesis that the risk of new-onset atrial fibrillation increases with increasing circulating levels of B-type natriuretic peptide in the general population.</p>
-                                <p>Methods: Participants in our health checkup program without atrial fibrillation or a history of atrial fibrillation were enrolled (n=10,058, 54.3±11.3 years old). After baseline evaluation, subjects were followed up for the median of 1,791 days with the endpoint being the new onset of atrial fibrillation.</p>
-                                <p>Results: Atrial fibrillation occurred in 53 subjects during the follow-up period (1.16 per 1,000 person-year). The risk of new-onset atrial fibrillation increased across the gender-specific quartiles of B-type natriuretic peptide levels at baseline. In multivariate Cox proportional hazard regression analysis where B-type natriuretic peptide concentrations were taken as a continuous variable, B-type natriuretic peptide was a significant predictor of new onset of atrial fibrillation after adjustment for possible factors (hazard ratio 5.65 [95% CI 2.63–12.41]).</p>
-                                <p>Conclusions: The risk of new onset of atrial fibrillation increases with increasing B-type natriuretic peptide levels in the general population. Measurement of B-type natriuretic peptide may improve the prediction of incident atrial fibrillation</p>
-                                <p><b>DOI: 10.4022/jafib.674</b></p>
-                            </div>
-
-                            <div class="reference HAVOC">
-                                <p><b>A Clinical Score for Predicting Atrial Fibrillation in Patients with Cryptogenic Stroke or Transient Ischemic Attack</b></p>
-                                <p>Calvin Kwong , Albee Y Ling, Michael H Crawford, Susan X Zhao, Nigam H Shah</p>
-                                <p>Abstract <br>
-                                    Objectives: Detection of atrial fibrillation (AF) in post-cryptogenic stroke (CS) or transient ischemic attack (TIA) patients carries important therapeutic implications.
-                                </p>
-                                <p>Methods: To risk stratify CS/TIA patients for later development of AF, we conducted a retrospective cohort study using data from 1995 to 2015 in the Stanford Translational Research Integrated Database Environment (STRIDE).
-                                    Results: Of the 9,589 adult patients (age ≥40 years) with CS/TIA included, 482 (5%) patients developed AF post CS/TIA. Of those patients, 28.4, 26.3, and 45.3% were diagnosed with AF 1-12 months, 1-3 years, and >3 years after the index CS/TIA, respectively. Age (≥75 years), obesity, congestive heart failure, hypertension, coronary artery disease, peripheral vascular disease, and valve disease are significant risk factors, with the following respective odds ratios (95% CI): 1.73 (1.39-2.16), 1.53 (1.05-2.18), 3.34 (2.61-4.28), 2.01 (1.53-2.68), 1.72 (1.35-2.19), 1.37 (1.02-1.84), and 2.05 (1.55-2.69). A risk-scoring system, i.e., the HAVOC score, was constructed using these 7 clinical variables that successfully stratify patients into 3 risk groups, with good model discrimination (area under the curve = 0.77).
-                                </p>
-                                <p>Conclusions: Findings from this study support the strategy of looking longer and harder for AF in post-CS/TIA patients. The HAVOC score identifies different levels of AF risk and may be used to select patients for extended rhythm monitoring.</p>
-                                <p>PMID: 28654919 PMCID: PMC5683906 DOI: 10.1159/000476030</p>
-                            </div>
-
-                            <div class="reference CHARGE-AF">
-                                <p><b>Simple risk model predicts incidence of atrial fibrillation in a racially and geographically diverse population: the CHARGE-AF consortium</b></p>
-                                <p>Alvaro Alonso , Bouwe P Krijthe, Thor Aspelund, Katherine A Stepas, Michael J Pencina, Carlee B Moser, Moritz F Sinner, Nona Sotoodehnia, João D Fontes, A Cecile J W Janssens, Richard A Kronmal, Jared W Magnani, Jacqueline C Witteman, Alanna M Chamberlain, Steven A Lubitz, Renate B Schnabel, Sunil K Agarwal, David D McManus, Patrick T Ellinor, Martin G Larson, Gregory L Burke, Lenore J Launer, Albert Hofman, Daniel Levy, John S Gottdiener, Stefan Kääb, David Couper, Tamara B Harris, Elsayed Z Soliman, Bruno H C Stricker, Vilmundur Gudnason, Susan R Heckbert, Emelia J Benjamin</p>
-                                <p>Abstract <br>
-                                    Background: Tools for the prediction of atrial fibrillation (AF) may identify high-risk individuals more likely to benefit from preventive interventions and serve as a benchmark to test novel putative risk factors.
-                                </p>
-                                <p>Methods and results: Individual-level data from 3 large cohorts in the United States (Atherosclerosis Risk in Communities [ARIC] study, the Cardiovascular Health Study [CHS], and the Framingham Heart Study [FHS]), including 18 556 men and women aged 46 to 94 years (19% African Americans, 81% whites) were pooled to derive predictive models for AF using clinical variables. Validation of the derived models was performed in 7672 participants from the Age, Gene and Environment-Reykjavik study (AGES) and the Rotterdam Study (RS). The analysis included 1186 incident AF cases in the derivation cohorts and 585 in the validation cohorts. A simple 5-year predictive model including the variables age, race, height, weight, systolic and diastolic blood pressure, current smoking, use of antihypertensive medication, diabetes, and history of myocardial infarction and heart failure had good discrimination (C-statistic, 0.765; 95% CI, 0.748 to 0.781). Addition of variables from the electrocardiogram did not improve the overall model discrimination (C-statistic, 0.767; 95% CI, 0.750 to 0.783; categorical net reclassification improvement, -0.0032; 95% CI, -0.0178 to 0.0113). In the validation cohorts, discrimination was acceptable (AGES C-statistic, 0.664; 95% CI, 0.632 to 0.697 and RS C-statistic, 0.705; 95% CI, 0.664 to 0.747) and calibration was adequate.</p>
-                                <p>Conclusion: A risk model including variables readily available in primary care settings adequately predicted AF in diverse populations from the United States and Europe</p>
-                                <p>PMID: 23537808 PMCID: PMC3647274 DOI: 10.1161/JAHA.112.000102</p>
-                            </div>
-
-                            <div class="reference HARMS2-AF">
-                                <p><b>New-onset atrial fibrillation prediction: the HARMS2-AF risk score</b></p>
-                                <p>Louise Segan, Rodrigo Canovas, Shane Nanayakkara , David Chieng , Sandeep Prabhu , Aleksandr Voskoboinik , Hariharan Sugumar , Liang-Han Ling , Geoff Lee , Joseph Morton , Andre LaGerche , David M Kaye , Prashanthan Sanders , Jonathan M Kalman , Peter M Kistler</p>
-                                <p>Abstract <br>
-                                    Aims: Lifestyle risk factors are a modifiable target in atrial fibrillation (AF) management. The relative contribution of individual lifestyle risk factors to AF development has not been described. Development and validation of an AF lifestyle risk score to identify individuals at risk of AF in the general population are the aims of the study.
-                                </p>
-                                <p>Methods and results: The UK Biobank (UKB) and Framingham Heart Study (FHS) are large prospective cohorts with outcomes measured >10 years. Incident AF was based on International Classification of Diseases version 10 coding. Prior AF was excluded. Cox proportional hazards regression identified independent AF predictors, which were evaluated in a multivariable model. A weighted score was developed in the UKB and externally validated in the FHS. Kaplan-Meier estimates ascertained the risk of AF development. Among 314 280 UKB participants, AF incidence was 5.7%, with median time to AF 7.6 years (interquartile range 4.5-10.2). Hypertension, age, body mass index, male sex, sleep apnoea, smoking, and alcohol were predictive variables (all P < 0.001); physical inactivity [hazard ratio (HR) 1.01, 95% confidence interval (CI) 0.96-1.05, P = 0.80] and diabetes (HR 1.03, 95% CI 0.97-1.09, P = 0·38) were not significant. The HARMS2-AF score had similar predictive performance [area under the curve (AUC) 0.782] to the unweighted model (AUC 0.802) in the UKB. External validation in the FHS (AF incidence 6.0% of 7171 participants) demonstrated an AUC of 0.757 (95% CI 0.735-0.779). A higher HARMS2-AF score (≥5 points) was associated with a heightened AF risk (score 5-9: HR 12.79; score 10-14: HR 38.70). The HARMS2-AF risk model outperformed the Framingham-AF (AUC 0.568) and ARIC (AUC 0.713) risk models (both P < 0.001) and was comparable to the CHARGE-AF risk score (AUC 0.754, P = 0.73).</p>
-                                <p>Conclusion: The HARMS2-AF score is a novel lifestyle risk score which may help identify individuals at risk of AF in the general community and assist population screening.</p>
-                                <p><b>PMID: 37350480 DOI: 10.1093/eurheartj/ehad375</b></p>
-                            </div>
-
-                            <div class="reference Hamada">
-                                <p><b>Simple risk model and score for predicting of incident atrial fibrillation in Japanese</b></p>
-                                <p>Richiro Hamada, Shigeki Muto </p>
-                                <p>Abstract <br>
-                                    Background
-                                    Investigating regarding a predicted risk score of incident atrial fibrillation (AF) for an Asian general population has not been enough. Whether addition of electrocardiogram (ECG) variables to risk factors improves prediction of incident AF is unclear in a context that ECGs are extensively used at medical check-ups and outpatient clinics in Japan.
-                                </p>
-                                <p>Methods <br>
-                                    Participants undergoing periodic health check-ups during 2008–2014 followed-up by December 2015 including 96,841 (65.1% male) aged 40–79 years were pooled to derive prediction models and risk scores for incident AF. Multivariable Cox regression identified clinical risk factors associated with incident AF in 7 years among 65,984 eligible participants including 349 AF cases.
-                                </p>
-                                <p>Results <br>
-                                    A 7-year prediction model ("Simple-model") including the variables of age, waist circumference, diastolic blood pressure, alcohol consumption, heart rate, and cardiac murmur, had good discrimination (C-statistic, 0.77), requiring no blood sampling. Addition model of the ECGs variables (“Added-model”) including left ventricular hypertrophy, atrial enlargement, atrial premature contraction, and ventricular premature contraction, improved significantly the overall model discrimination (C-statistic, 0.78; categorical net reclassification improvement, 0.063; 95%CI, 0.031–0.099). The risk scores derived from the two models respectively showed an approximation of the observed and predicted probability for each score. Participants with score ≤4 or ≥9 points had, respectively, ≤1% and ≥5% predicted probability of incident AF in 7 years. The receiver-operating characteristics curve for the risk score of the added-model was significantly higher than the simple-model (0.769 vs 0.753, p < 0.001). Atrial enlargement on ECG and the highest age group were the highest risk points of the significant predictors.
-                                </p>
-                                <p>Conclusions <br>
-                                    We developed 7-year risk scores for incident AF using usually available clinical factors including ECGs in primary care. These risk scores could identify individuals with high risk of incident AF at health check-up and outpatient clinics.
-                                </p>
-                                <p><b>DOI 10.1016/j.jjcc.2018.06.005</b></p>
-                            </div>
-
-                            <div class="reference MayoScore">
-                                <p><b>Clinical Predictors of Risk for Atrial Fibrillation: Implications for Diagnosis and Monitoring</b></p>
-                                <p>Kyle J. Brunner, MBA; T. Jared Bunch, MD; Christopher M. Mullin, MS; Heidi T. May, PhD; Tami L. Bair, BS; David W. Elliot, MBA; Jeffrey L. Anderson, MD; and Srijoy Mahapatra, MD</p>
-                                <p>Abstract <br>
-                                    Objective: To create a risk score using clinical factors to determine whom to screen and monitor for atrial fibrillation (AF). <br>
-                                    Patients and Methods: The AF risk score was developed based on the summed odds ratios (ORs) for AF development of 7 accepted clinical risk factors. The AF risk score is intended to assess the risk of AF similar to
-                                    how the CHA2DS2-VASc score assesses stroke risk. Seven validated risk factors for AF were used to develop the AF risk score: age, coronary artery disease, diabetes mellitus, sex, heart failure, hypertension, and valvular
-                                    disease. The AF risk score was tested within a random population sample of the Intermountain Healthcare outpatient database. Outcomes were stratified by AF risk score for OR and Kaplan-Meier analysis.<br>
-                                    Results: A total of 100,000 patient records with an index follow-up from January 1, 2002, through December 31, 2007, were selected and followed up for the development of AF through the time of this analysis, May 13, 2013, through September 6, 2013. Mean SD follow-up time was 3106 - 819 days. The ORs of subsequent AF diagnosis of patients with AF risk scores of 1, 2, 3, 4, and 5 or higher were 3.05, 12.9, 22.8, 34.0, and 48.0, respectively. The area under the curve statistic for the AF risk score was 0.812 (95% CI, 0.805-0.820). <br>
-                                    Conclusion: We developed a simple AF risk score made up of common clinical factors that may be useful to possibly select patients for long-term monitoring for AF detection.
-                                </p>
-                                <p><b>DOI 10.1016/j.mayocp.2014.08.016</b></p>
-                            </div>
-
-                            <div class="reference HATCH">
-                                <p><b>Usefulness of HATCH score in the prediction of new-onset atrial fibrillation for Asians</b></p>
-                                <p>Kazuyoshi Suenari, MD, Tze-Fan Chao, MD, Chia-Jen Liu, MD, Yasuki Kihara, MD,Tzeng-Ji Chen, MD, Shih-Ann Chen, MD</p>
-                                <p>Abstract <br>
-                                    The HATCH score (hypertension <1 point>, age >75 years <1 point>, stroke or transient ischemic attack <2 points>, chronic obstructive pulmonary disease <1 point>, and heart failure <2 points>) was reported to be useful for predicting the progression of atrial fibrillation (AF) from paroxysmal to persistent or permanent AF for patients who participated in the Euro Heart Survey. The goal of the current study was to investigate whether the HATCH score was a useful scheme in predicting new-onset AF. Furthermore, we aimed to use the HATCH scoring system to estimate the individual risk in developing AF for patients with different comorbidities. We used the “Taiwan National Health Insurance Research Database.” From January 1, 2000, to December 31, 2001, a total of 670,804 patients older than 20 years old and who had no history of cardiac arrhythmias were enrolled. According to the calculation rule of the HATCH score, 599,780 (score 0), 46,661 (score 1), 12,892 (score 2), 7456 (score 3), 2944 (score 4), 802 (score 5), 202 (score 6), and 67 (score 7) patients were studied and followed for the new onset of AF. During a follow-up of 9.0 ± 2.2 years, there were 9174 (1.4%) patients experiencing new-onset AF. The incidence of AF was 1.5 per 1000 patient-years. The incidence increased from 0.8 per 1000pat ient-years for patients with a HATCH score of 0 to 57.3 per 1000 patient-years for those with a HATCH score of 7. After an adjustment for the gender and comorbidities, the hazard ratio (95% confidence interval) of each increment of the HATCH score in predicting AF was 2.059 (2.027–2.093; P<0.001). The HATCH score was useful in risk estimation and stratification of new-onset AF. <br>
-                                    Abbreviations: AF = atrial fibrillation, ARIC = atherosclerosis risk in communities, COPD = chronic obstructive pulmonary disease, FEV1 = forced expiratory volume in 1 second, NHIRD = National Health Insurance Research Database, TIA = transient ischemic attack.
-                                </p>
-                                <p><b>DOI 10.1097/MD.0000000000005597</b></p>
-                            </div>
-
-                            <div class="reference FraminghamAFriskscore">
-                                <p><b>Development of a Risk Score for Atrial Fibrillation in the Community; The Framingham Heart Study</b></p>
-                                <p>Renate B. Schnabel, MD, Lisa M. Sullivan, PhD, Daniel Levy, MD, Michael J. Pencina, PhD, Joseph M. Massaro, PhD, Ralph B. D’Agostino Sr, PhD, Christopher Newton-Cheh, MD, MPH, Jennifer F. Yamamoto, BS, Jared W. Magnani, MD, Thomas M. Tadros, MD, MPH, William B. Kannel, MD, Thomas J. Wang, MD, Patrick T. Ellinor, MD, PhD, Philip A Wolf, MD, Ramachandran S. Vasan, MD, and Emelia J. Benjamin, MD, ScM</p>
-                                <p>Abstract <br>
-                                    Background—Atrial fibrillation (AF) contributes to substantial increases in morbidity and mortality. Our aim was to develop a risk prediction model to assess individuals’ absolute risk for incident AF; to offer clinicians a tool to communicate risk; and to provide researchers a framework to evaluate new risk markers. <br>
-                                    Methods—We examined 4764 Framingham Heart Study individuals (8044 person-exams; mean age 60.9 years, 55% women) aged 45–95 years. Multivariable Cox regression related clinical variables to 10-year AF incidence (n=457). Secondary analyses incorporated routine echocardiographic data (person-exams=7156, 445 events) for reclassifying individuals’ AF risk.<br>
-                                    Findings—Age, sex, significant murmur, heart failure, systolic blood pressure, hypertension treatment, body mass index, and electrocardiographic PR interval were associated with incident AF (p<0.05; clinical model C statistic=0.78, 95% confidence interval [CI] 0.76–0.80). Ten-year AF risk varied with age; >15% 10-year AF risk was observed in 1.0% of individuals <65 years versus 26.9% of participants ≥65 years. Predicted 10-year risk deciles for developing AF were similar to observed risks (calibration Chi-square statistic, 4.16, p=0.90). Additional incorporation of echocardiographic features minimally improved the C statistic from 0.78 (0.75, 0.80) to 0.79 (95% CI 0.77–0.82), p=0.005. Echocardiographic variables did not significantly improve net reclassification (p=0.18). We provide a point score for estimating AF risk with variables easily-measured in primary care. Interpretation—The Framingham AF risk score may help risk stratify individuals in the community, and may provide a framework to evaluate new biological or genetic markers for AF risk prediction and help target individuals destined to develop AF for preventive measures.
-                                </p>
-                                <p><b>DOI:10.1016/S0140-6736(09)60443-8</b></p>
-                            </div>                         
-
-                            <div class="reference MHSScore">
-                                <p><b>Risk Score for Prediction of 10-Year Atrial Fibrillation: A Community-Based Study</b></p>
-                                <p>Doron Aronson, Varda Shalev, Rachel Katz, Gabriel Chodick, Diab Mutlak</p>
-                                <p>Purpose We used a large real-world data from community settings to develop and validate a 10-year risk score for new-onset atrial fibrillation (AF) and calculate its net benefit performance. <br>
-                                    Methods Multivariable Cox proportional hazards model was used to estimate effects of risk factors in the derivation cohort (n = 96,778) and to derive a risk equation. <br>
-                                    Measures of calibration and discrimination were calculated in the validation cohort (n = 48,404).  <br>
-                                    Results Cumulative AF incidence rates for both the derivation and validation cohorts were 5.8% at 10 years. The final models included the following variables: age, sex, body mass index, history of treated hypertension, systolic blood pressure > 160 mm Hg,
-                                    chronic lung disease, history of myocardial infarction, history of peripheral arterial disease, heart failure and history of an inflammatory disease. There was a 27-fold difference (1.0% vs. 27.2%) in AF risk between the lowest (–1) and the highest (9) sum score. The c-statistic was 0.743 (95% confidence interval [CI], 0.737–0.749) for the derivation cohort and 0.749 (95% CI, 0.741–0.759) in the validation cohort. The risk
-                                    equation was well calibrated, with predicted risks closely matching observed risks. Decision curve analysis displayed consistent positive net benefit of using the AF risk score for decision thresholds between 1 and 25% 10-year AF risk. <br>
-                                    Conclusion We provide a simple score for the prediction of 10-year risk for AF. The score can be used to select patients at highest risk for treatments of modifiable risk factors, monitoring for sub-clinical AF detection or for clinical trials of primary prevention of AF.
-                                </p>
-                                <p><b>DOI: 10.1055/s-0038-1668522</b></p>
-                            </div>
-
-                            <div class="reference ARICScore">
-                                <p><b>A clinical risk score for atrial fibrillation in a biracial prospective cohort (from the Atherosclerosis Risk in Communities [ARIC] study)</b></p>
-                                <p>Alanna M Chamberlain , Sunil K Agarwal, Aaron R Folsom, Elsayed Z Soliman, Lloyd E Chambless, Richard Crow, Marietta Ambrose, Alvaro Alonso</p>
-                                <p>Abstract <br>
-                                    A risk score for atrial fibrillation (AF) has been developed by the Framingham Heart Study; however, the applicability of this risk score, derived using data from white patients, to predict new-onset AF in nonwhites is uncertain. Therefore, we developed a 10-year risk score for new-onset AF from risk factors commonly measured in clinical practice using 14,546 subjects from the Atherosclerosis Risk In Communities (ARIC) study, a prospective community-based cohort of blacks and whites in the United States. During 10 years of follow-up, 515 incident AF events occurred. The following variables were included in the AF risk score: age, race, height, smoking status, systolic blood pressure, hypertension medication use, precordial murmur, left ventricular hypertrophy, left atrial enlargement, diabetes, coronary heart disease, and heart failure. The area under the receiver operating characteristics curve (AUC) of a Cox regression model that included the previous variables was 0.78, suggesting moderately good discrimination. The point-based score developed from the coefficients in the Cox model had an AUC of 0.76. This clinical risk score for AF in the Atherosclerosis Risk In Communities cohort compared favorably with the Framingham Heart Study's AF (AUC 0.68), coronary heart disease (CHD) (AUC 0.63), and hard CHD (AUC 0.59) risk scores and the Atherosclerosis Risk In Communities CHD risk score (AUC 0.58). In conclusion, we have developed a risk score for AF and have shown that the different pathophysiologies of AF and CHD limit the usefulness of a CHD risk score in identifying subjects at greater risk of AF.
-                                </p>
-                                <p><b>DOI: 10.1016/j.amjcard.2010.08.049</b></p>
-                            </div>                          
-
-                            <div class="reference Suita">
-                                <p><b>Development of a Basic Risk Score for Incident Atrial Fibrillation in a Japanese General Population　― The Suita Study</b></p>
-                                <p>Yoshihiro Kokubo, Makoto Watanabe, Aya Higashiyama, Yoko M Nakao, Kengo Kusano, Yoshihiro Miyamoto</p>
-                                <p>Background:An atrial fibrillation (AF) risk score for a non-Western general population has not been established.</p>
-                                <p>Methods and Results:A total of 6,898 participants (30–79 years old) initially free of AF have been prospectively followed for incident AF since 1989. AF was diagnosed when AF or atrial flutter was present on ECG at a biannual health examination; was indicated as a current illness; or was in the medical records during follow-up. Cox proportional hazard ratios were analyzed after adjusting for cardiovascular risk factors at baseline. During the 95,180 person-years of follow-up, 311 incident AF events occurred. We developed a scoring system for each risk factor as follows: 0/−5, 3/0, 7/5, and 9/9 points for men/women in their 30 s–40 s, 50 s, 60 s, and 70 s, respectively; 2 points for systolic hypertension, overweight, excessive drinking, or coronary artery disease; 1 point for current smoking; −1 point for moderate non-high-density lipoprotein-cholesterol; 4 points for arrhythmia; and 8, 6, and 2 points for subjects with cardiac murmur in their 30 s–40 s, 50 s, and 60 s, respectively (C-statistic 0.749; 95% confidence interval, 0.724−0.774). Individuals with score ≤2, 10–11, or ≥16 points had, respectively, ≤1%, 9%, and 27% observed probability of developing AF in 10 years.</p>
-                                <p>Conclusions:We developed a 10-year risk score for incident AF using traditional risk factors that are easily obtained in routine outpatient clinics/health examinations without ECG.</p>
-                                <p><b>DOI: 10.1253/circj.CJ-17-0277</b></p>
-                            </div>
-
-                            <div class="reference TaiwanAFScore">
-                                <p><b>Clinical Risk Score for the Prediction of Incident Atrial Fibrillation: Derivation in 7 220 654 Taiwan Patients With 438 930 Incident Atrial Fibrillations During a 16-Year Follow-Up</b></p>
-                                <p>Tze-Fan Chao, Chern-En Chiang, Tzeng-Ji Chen , Jo-Nan Liao, Ta-Chuan Tuan, Shih-Ann Chen</p>
-                                <p>Background Although several risk schemes have been proposed to predict new-onset atrial fibrillation (AF), clinical prediction models specific for Asian patients were limited. In the present study, we aimed to develop a clinical risk score (Taiwan AF score) for AF prediction using the whole Taiwan population database with a long-term follow-up. Methods and Results Among 7 220 654 individuals aged ≥40 years without a past history of cardiac arrhythmia identified from the Taiwan Health Insurance Research Database, 438 930 incident AFs occurred after a 16-year follow-up. Clinical risk factors of AF were identified using Cox regression analysis and then combined into a clinical risk score (Taiwan AF score). The Taiwan AF score included age, male sex, and important comorbidities (hypertension, heart failure, coronary artery disease, end-stage renal disease, and alcoholism) and ranged from -2 to 15. The area under the receiver operating characteristic curve of the Taiwan AF scores in the predictions of AF are 0.857 for the 1-year follow-up, 0.825 for the 5-year follow-up, 0.797 for the 10-year follow-up, and 0.756 for the 16-year follow-up. The annual risks of incident AF were 0.21%/year, 1.31%/year, and 3.37%/year for the low-risk (score -2 to 3), intermediate-risk (score 4 to 9), and high-risk (score ≥10) groups, respectively. Compared with low-risk patients, the hazard ratios of incident AF were 5.78 (95% CI, 3.76-7.75) for the intermediate-risk group and 8.94 (95% CI, 6.47-10.80) for the high-risk group. Conclusions We developed a clinical AF prediction model, the Taiwan AF score, among a large-scale Asian cohort. The new score could help physicians to identify Asian patients at high risk of AF in whom more aggressive and frequent detections and screenings may be considered.</p>
-                                <p><b>DOI: 10.1161/JAHA.120.020194</b></p>
-                            </div>
-
+            <!-- References modal (markup preserved from previous version, re-classed) -->
+            <div class="modal-backdrop" id="referenceModal" role="dialog" aria-modal="true" aria-labelledby="referenceModalLabel">
+                <div class="modal-dialog">
+                    <div class="modal-head">
+                        <h2 id="referenceModalLabel">Reference</h2>
+                        <button type="button" class="modal-close" aria-label="Close">×</button>
+                    </div>
+                    <div class="modal-body" id="referenceBody">
+                        <!-- Keep all <div class="reference <KEY>"> blocks from the previous version -->
+                        <div class="reference STAF">
+                            <p><b>Score for the Targeting of Atrial Fibrillation (STAF)</b></p>
+                            <p>Laurent Suissa, MD; David Bertora, MD; Sylvain Lachaud, MD; Marie Hélène Mahagne, MD, PhD</p>
+                            <p>STAF, calculated from the sum of the points for the 4 items (possible total score 0 to 8): age ≥62 years (2 points); NIHSS ≥8 (1 point); left atrial dilatation (2 points); absence of symptomatic intra/extracranial stenosis ≥50% or clinico-radiological lacunar syndrome (3 points). STAF ≥5 identified patients with AF with sensitivity 89% and specificity 88%.</p>
+                            <p><b>DOI: 10.1161/STROKEAHA.109.552679</b></p>
                         </div>
-                        
+                        <div class="reference BRAFIL">
+                            <p><b>A predictive score of Atrial Fibrillation in post-stroke patients</b></p>
+                            <p>Teixeira CT, Rizelio V, Robles A, Barros LCM, Silva GS, Andrade JBC.</p>
+                            <p>Score built with left atrial diameter ≥42 mm (2), age ≥70 years (1), septal aneurysm (2), NIHSS ≥6 at admission (1). Range 0–6. Score ≥2 → 5-fold AF risk. AUC 0.77 (0.72–0.85).</p>
+                        </div>
+                        <div class="reference TheHeinzNixdorfRecallStudy">
+                            <p><b>B-type natriuretic peptide for incident AF — Heinz Nixdorf Recall Study</b></p>
+                            <p>Kara K, Geisel MH, Möhlenkamp S, et al.</p>
+                            <p>Elevated BNP levels are associated with significant excess of incident AF, independent of traditional risk factors. Gender-specific thresholds: ≥31 pg/ml male, ≥45 pg/ml female.</p>
+                            <p><b>doi: 10.1016/j.jjcc.2014.08.003</b></p>
+                        </div>
+                        <div class="reference ASAS">
+                            <p><b>Acute Stroke Atrial Fibrillation Scoring System (ASAS)</b></p>
+                            <p>Figueiredo MM, Rodrigues ACT, Alves MB, Cendoroglo Neto M, Silva GS.</p>
+                            <p>AF predictors: age, NIHSS, presence of left atrial enlargement. AUC 0.79 derivation, 0.76 validation.</p>
+                            <p><b>DOI: 10.6061/clinics/2014(04)04</b></p>
+                        </div>
+                        <div class="reference CHA2DS2-VASC">
+                            <p><b>CHADS2 / CHA2DS2-VASc for new-onset AF</b></p>
+                            <p>Saliba W, Gronich N, Barnett-Griness O, Rennert G.</p>
+                            <p>Each 1-point increase in CHA2DS2-VASc: hazard ratio 1.57 (95% CI 1.56–1.58). AUC for predicting new-onset AF: 0.744.</p>
+                            <p><b>PMID: 27012854 · DOI: 10.1016/j.amjmed.2016.02.029</b></p>
+                        </div>
+                        <div class="reference C2HEST">
+                            <p><b>C2HEST score for AF risk — meta-analysis</b></p>
+                            <p>Haybar H, Shirbandi K, Rahim F.</p>
+                            <p>Each 1-point increase: OR 1.03 (95% CI 1.01–1.05). Overall AUC 0.91 (0.85–0.96).</p>
+                            <p><b>PMID: 34862957 · DOI: 10.1186/s43044-021-00230-0</b></p>
+                        </div>
+                        <div class="reference Takase">
+                            <p><b>Prediction of AF by B-type Natriuretic Peptide</b></p>
+                            <p>Takase H, Dohi Y, Sonoda H, Kimura G.</p>
+                            <p>BNP as continuous variable: HR 5.65 (95% CI 2.63–12.41) for new-onset AF, adjusted for risk factors.</p>
+                            <p><b>DOI: 10.4022/jafib.674</b></p>
+                        </div>
+                        <div class="reference HAVOC">
+                            <p><b>HAVOC — A Clinical Score for Predicting AF in Cryptogenic Stroke/TIA</b></p>
+                            <p>Kwong C, Ling AY, Crawford MH, Zhao SX, Shah NH.</p>
+                            <p>7 clinical variables (age ≥75, obesity, CHF, hypertension, CAD, PVD, valve disease). AUC 0.77.</p>
+                            <p><b>PMID: 28654919 · DOI: 10.1159/000476030</b></p>
+                        </div>
+                        <div class="reference CHARGE-AF">
+                            <p><b>CHARGE-AF — Simple risk model for AF incidence</b></p>
+                            <p>Alonso A, Krijthe BP, Aspelund T, et al.</p>
+                            <p>5-year model (age, race, height, weight, BP, smoking, antihypertensive use, diabetes, MI, HF). Derivation C-statistic 0.765.</p>
+                            <p><b>PMID: 23537808 · DOI: 10.1161/JAHA.112.000102</b></p>
+                        </div>
+                        <div class="reference HARMS2-AF">
+                            <p><b>HARMS2-AF — New-onset AF lifestyle risk score</b></p>
+                            <p>Segan L, Canovas R, Nanayakkara S, et al.</p>
+                            <p>Predictors: hypertension, age, BMI, male sex, sleep apnoea, smoking, alcohol. 5-year AUC 0.757; 10-year AUC 0.753.</p>
+                            <p><b>PMID: 37350480 · DOI: 10.1093/eurheartj/ehad375</b></p>
+                        </div>
+                        <div class="reference Hamada">
+                            <p><b>Simple risk model and score for predicting incident AF in Japanese</b></p>
+                            <p>Hamada R, Muto S.</p>
+                            <p>7-year model (age, waist circumference, diastolic BP, alcohol, heart rate, cardiac murmur) + ECG add-on (LVH, atrial enlargement, APC, VPC). C-statistic 0.77 simple, 0.78 added.</p>
+                            <p><b>DOI: 10.1016/j.jjcc.2018.06.005</b></p>
+                        </div>
+                        <div class="reference MayoScore">
+                            <p><b>Clinical Predictors of Risk for AF — Mayo</b></p>
+                            <p>Brunner KJ, Bunch TJ, Mullin CM, et al.</p>
+                            <p>7 validated risk factors. AUC 0.812 (95% CI 0.805–0.820).</p>
+                            <p><b>DOI: 10.1016/j.mayocp.2014.08.016</b></p>
+                        </div>
+                        <div class="reference HATCH">
+                            <p><b>HATCH score in Asians</b></p>
+                            <p>Suenari K, Chao TF, Liu CJ, Kihara Y, Chen TJ, Chen SA.</p>
+                            <p>Hypertension (1), age &gt;75 (1), stroke/TIA (2), COPD (1), heart failure (2). HR per 1-point increase 2.059 (2.027–2.093).</p>
+                            <p><b>DOI: 10.1097/MD.0000000000005597</b></p>
+                        </div>
+                        <div class="reference FraminghamAFriskscore">
+                            <p><b>Framingham AF Risk Score</b></p>
+                            <p>Schnabel RB, Sullivan LM, Levy D, et al.</p>
+                            <p>Variables: age, sex, significant murmur, HF, systolic BP, hypertension treatment, BMI, ECG PR interval. C-statistic 0.78.</p>
+                            <p><b>DOI: 10.1016/S0140-6736(09)60443-8</b></p>
+                        </div>
+                        <div class="reference MHSScore">
+                            <p><b>MHS 10-year AF Risk Score</b></p>
+                            <p>Aronson D, Shalev V, Katz R, Chodick G, Mutlak D.</p>
+                            <p>Variables: age, sex, BMI, treated hypertension, SBP &gt;160, chronic lung disease, MI, PAD, HF, inflammatory disease. C-statistic 0.743–0.749.</p>
+                            <p><b>DOI: 10.1055/s-0038-1668522</b></p>
+                        </div>
+                        <div class="reference ARICScore">
+                            <p><b>ARIC Risk Score for AF</b></p>
+                            <p>Chamberlain AM, Agarwal SK, Folsom AR, et al.</p>
+                            <p>Variables: age, race, height, smoking, SBP, hypertension treatment, precordial murmur, LVH, LAE, diabetes, CHD, HF. AUC 0.76.</p>
+                            <p><b>DOI: 10.1016/j.amjcard.2010.08.049</b></p>
+                        </div>
+                        <div class="reference Suita">
+                            <p><b>Suita Study — Japanese 10-year AF risk</b></p>
+                            <p>Kokubo Y, Watanabe M, Higashiyama A, Nakao YM, Kusano K, Miyamoto Y.</p>
+                            <p>C-statistic 0.749 (95% CI 0.724–0.774). Score ≤2 → ≤1%; 10–11 → 9%; ≥16 → 27% observed 10-year AF probability.</p>
+                            <p><b>DOI: 10.1253/circj.CJ-17-0277</b></p>
+                        </div>
+                        <div class="reference TaiwanAFScore">
+                            <p><b>Taiwan AF Score</b></p>
+                            <p>Chao TF, Chiang CE, Chen TJ, Liao JN, Tuan TC, Chen SA.</p>
+                            <p>Age, male sex, hypertension, HF, CAD, ESRD, alcoholism. Range −2 to 15. AUC: 0.857 (1-yr), 0.825 (5-yr), 0.797 (10-yr), 0.756 (16-yr).</p>
+                            <p><b>DOI: 10.1161/JAHA.120.020194</b></p>
+                        </div>
                     </div>
                 </div>
             </div>
+        <?php endif; ?>
+    </main>
 
-        </div>	
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
-	</div>
+    <?php $this->load->view('footer'); ?>
+    <script src="<?php echo base_url('assets/js/export.js'); ?>"></script>
+
+    <script>
+        // Reference modal + score tooltips — kept from the previous version
+        (function(){
+            const modal = document.getElementById('referenceModal');
+            const closeBtn = modal ? modal.querySelector('.modal-close') : null;
+            const refs = modal ? modal.querySelectorAll('.reference') : [];
+            function openModal(id) {
+                refs.forEach(r => r.classList.toggle('active', r.classList.contains(id)));
+                modal.classList.add('show');
+            }
+            function closeModal() { if (modal) modal.classList.remove('show'); }
+            document.querySelectorAll('.show-reference').forEach(btn => {
+                btn.addEventListener('click', () => openModal(btn.dataset.ref));
+            });
+            if (closeBtn) closeBtn.addEventListener('click', closeModal);
+            if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeModal(); });
+            document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeModal(); });
+
+            // Score tooltips — attach to each .ref-btn by score key
+            if (!window.tippy) return;
+            const tips = {
+                STAF: 'A total score of ≥5 identifies patients with AF with sensitivity 89% and specificity 88%.',
+                ASAS: 'AUC 0.78 (95% CI 0.70–0.86), excluding previous AF diagnosis.',
+                'CHA2DS2-VASC': 'AUC 0.744 for new-onset AF over 2-year follow-up.',
+                HAVOC: 'Chance (%) of AF in 3 years; AUC 0.77.',
+                'CHARGE-AF': 'Chance (%) of AF in 5 years.',
+                'HARMS2-AF': 'Hazard ratio for AF detection up to 10 years. 5-year AUC 0.757; 10-year AUC 0.753.',
+                Hamada: '7-year risk of AF; AUC 0.78.',
+                MayoScore: 'Incident AF in ~8-year follow-up; AUC 0.812.',
+                HATCH: 'Chance of AF detection in ~10 years; AUC 0.716.',
+                MHSScore: '10-year predicted risk of AF; AUC 0.749.',
+                ARICScore: 'Chance (%) of AF in 10 years; AUC 0.76.',
+                Suita: '10-year predicted risk of AF; AUC 0.749.',
+                TaiwanAFScore: 'Cumulative incidence of AF in 1–16 year follow-up; AUC 0.857 (1yr) to 0.756 (16yr).'
+            };
+            document.querySelectorAll('.ref-btn').forEach(btn => {
+                const key = btn.dataset.ref;
+                if (tips[key]) tippy(btn, { content: tips[key], theme: 'customTooltipCssTema', placement: 'top' });
+            });
+        })();
+    </script>
 </body>
-<footer>
-	<?php $this->load->view('footer'); ?>
-</footer>
-
-<script>
-    $(document).ready(function(){
-        $('.btn-calculate').click(function(){
-            window.location.href = "<?php echo base_url('home'); ?>";
-        });
-
-       
-    });
-
-    $('.show-reference').click(function(){
-        $('.reference').css('display', 'none');
-
-        var id = $(this).attr('id');
-        $('.'+id).css('display', 'block');
-        $('#referenceModal').modal('show');
-
-    });
-
-    tippy('#STAF', {
-        content: 'A total score of ≥5 enabled the identification of patients with AF in 3 months with a sensitivity of 89% (95% CI, 83 to 94) and a specificity of 88% (95% CI, 84 to 91)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#ASAS', {
-        content: 'The AUC for the predicted probabilities of the ASAS was 0.78 [95%CI 0.70-0.86], excluding patients with a previous diagnosis of atrial fibrillation.',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#CHA2DS2-VASC', {
-        content: 'Predicting a new-onset atrial fibrillation in 2-years follow-up (AUC 0.744 (95% CI, 0.741-0.747)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#HAVOC', {
-        content: 'Chance (%) of Afib in 3 years (AUC 0.77)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#CHARGE-AF', {
-        content: 'Chance (%) of Afib in 5 year',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#HARMS2-AF', {
-        content: 'Hazard ratio (HR) for Afib detection in up to 10 years. Performance with a 5-year AUC 0.757 (95% CI 0.735–0.779) and 10-year AUC 0.753 (95% CI 0.732–0.775)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#Hamada', {
-        content: 'A 7-year risk of atrial fibrillation (AUC 0.78)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#MayoScore', {
-        content: 'Predicting incidente AFib in about 8-years follow-up (AUC 0.812 (95% CI, 0.805-0.820))',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#HATCH', {
-        content: 'Chance of AFib detection in about 10 years (AUC 0.716 (95% CI 0.710–0.723). Results from an external validation in a Taiwanese cohort.',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#MHSScore', {
-        content: 'A 10-years predicted risk of AFib (AUC 0.749 (0.740–0.758)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#ARICScore', {
-        content: 'Chance (%) of Afib in 10 years (The point-based score developed from coefficients in the Cox model had an AUC of 0.76.)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#Suita', {
-        content: 'Predicted 10-Year Risk of Incident AF (AUC 0.749; 95% CI 0.724−0.774)',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-    tippy('#TaiwanAFScore', {
-        content: 'Cumulative Incidence of AFib in a 1 to 16-years follow-up. AUC ranged from 0.857 (0.855–0.860) to 0.756 (0.755–0.757) in follow-up of 1 or 16 years, respectively',
-        theme: 'customTooltipCssTema', 
-        arrow: false,
-        placement: 'auto',
-    });
-
-</script>
 </html>

--- a/plataforma/application/views/resultado/home.php
+++ b/plataforma/application/views/resultado/home.php
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <?php $this->load->view('header'); ?>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha512-GsLlZN/3F2ErC5ifS5QtgpiJtWd43JWSuIgh7mbzZ8zBps+dvLusV+eNQATqgA/HdeKFVgA5v3S/cIrLF7QnIg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/3.0.3/jspdf.umd.min.js" integrity="sha512-+EeCylkt9WHJk5tGJxYdecHOcXFRME7qnbsfeMsdQL6NUPYm2+uGFmyleEqsmVoap/f3dN/sc3BX9t9kHXkHHg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <body>
     <header class="topbar">
@@ -71,16 +71,6 @@
             <script>
                 window.AFIBRISK_INPUTS = <?= json_encode($respostas, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG) ?>;
             </script>
-
-            <!-- Offscreen PDF template: export.js fills `#pdfBody` on demand -->
-            <div class="pdf-template" id="pdfTemplate" aria-hidden="true">
-                <h1>AFibRisk — Assessment Report</h1>
-                <div id="pdfBody"></div>
-                <footer>
-                    Not a medical device. This report is for educational/research use only.
-                    See the About page for the full disclaimer.
-                </footer>
-            </div>
 
             <!-- References modal (markup preserved from previous version, re-classed) -->
             <div class="modal-backdrop" id="referenceModal" role="dialog" aria-modal="true" aria-labelledby="referenceModalLabel">

--- a/plataforma/application/views/resultado/home.php
+++ b/plataforma/application/views/resultado/home.php
@@ -69,7 +69,7 @@
 
             <!-- Inputs payload for export.js -->
             <script>
-                window.AFIBRISK_INPUTS = <?= json_encode($respostas, JSON_UNESCAPED_UNICODE) ?>;
+                window.AFIBRISK_INPUTS = <?= json_encode($respostas, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG) ?>;
             </script>
 
             <!-- Offscreen PDF template: export.js fills `#pdfBody` on demand -->

--- a/plataforma/application/views/sobre.php
+++ b/plataforma/application/views/sobre.php
@@ -1,54 +1,39 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-	<?php $this->load->view('header'); ?>
+    <?php $this->load->view('header'); ?>
 </head>
-<body id="background1">
-	
-	<div class="container container-sobre">
+<body>
+    <header class="topbar">
+        <a href="<?php echo base_url(); ?>" class="brand">AFibRisk</a>
+        <nav>
+            <a href="<?php echo base_url(); ?>">Home</a>
+        </nav>
+    </header>
 
-		<div id="sobre">
-			
-			<div class="row" style="text-align: center;">
-				<div class="col-md-12">
-					<p>Created by Joao Brainer C de Andrade, MD, PhD</p>
-					<p>Universidade Federal de São Paulo, Brazil</p>
-					<p>Department of Health Informatics</p>
-					<p>Departament of Neurology</p>
-					<p>joao.brainer@unifesp.br</p>
-				</div>
-			</div>
-					
-			<div class="row" style="text-align: center;">
-				<div class="col-md-12">
-					<p>Application developed by <a href="https://www.linkedin.com/in/danielsciarotta/" target="_blank">Daniel Sciarotta Zaveri</a></p>
-				</div>
-			</div>
-			
-			<div class="row" style="text-align: center;">
-				<div class="col-md-12">					
-					<h3>DISCLAIMER</h3>
-				</div>
-			</div>
-			<div class="row" style="text-align: left;">
-				<div class="col-md-12">
-					<p>THIS APPLICATION IS MADE AVAILABLE SOLELY FOR PERSONAL NON-COMMERCIAL, TEACHING AND EDUCATIONAL USE. THIS APPLICATION IS NOT A MEDICAL DEVICE AND DOES NOT AND SHOULD NOT BE CONSTRUED TO PROVIDE HEALTH-RELATED OR MEDICAL ADVICE, OR CLINICAL DECISION SUPPORT, OR TO SUPPORT OR REPLACE THE DIAGNOSIS, OR ANOTHER KIND OF MEDICAL DECISION. THIS APPLICATION DOES NOT CREATE A PHYSICIAN-PATIENT RELATIONSHIP BETWEEN THE ABOVE-MENTIONED INSTITUTIONS AND ANY INDIVIDUAL. YOU, THE USER, AGREE TO USE THIS APPLICATION UNDER ALL THESE TERMS AND CONDITIONS. IF YOU DO NOT AGREE TO ALL OF THESE TERMS OF USE, DO NOT USE THIS SITE.</p>
+    <main class="container-narrow">
+        <h1>About AFibRisk</h1>
 
-					<p>DR. JOAO ANDRADE AND THE DEVELOPERS MAKE NO REPRESENTATIONS AS TO ANY MATTER WHATSOEVER, INCLUDING ACCURACY, FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.</p>
+        <section class="about-section about-credits">
+            <p>Created by Joao Brainer C de Andrade, MD, PhD</p>
+            <p>Universidade Federal de São Paulo, Brazil</p>
+            <p>Department of Health Informatics</p>
+            <p>Department of Neurology</p>
+            <p><a href="mailto:joao.brainer@unifesp.br">joao.brainer@unifesp.br</a></p>
+        </section>
 
-					<p>DR. JOAO ANDRADE AND THE DEVELOPERS ARE NOT LIABLE TO YOU OR ANYONE ELSE FOR ANY DECISION MADE OR ACTION TAKEN BASED ON RELIANCE UPON THE INFORMATION CONTAINED ON OR PROVIDED THROUGH THIS WEBSITE. THE USE OF THE INFORMATION SHALL BE AT YOUR OWN RISK.</p>
-				
-				</div>
-			</div>		
+        <section class="about-section">
+            <p>Application developed by <a href="https://www.linkedin.com/in/danielsciarotta/" target="_blank" rel="noopener">Daniel Sciarotta Zaveri</a>.</p>
+        </section>
 
-		</div>
+        <section class="disclaimer-card">
+            <h2>Disclaimer</h2>
+            <p>This application is made available solely for personal non-commercial, teaching and educational use. This application is NOT a medical device and does not and should not be construed to provide health-related or medical advice, or clinical decision support, or to support or replace the diagnosis, or another kind of medical decision. This application does not create a physician–patient relationship between the above-mentioned institutions and any individual. You, the user, agree to use this application under all these terms and conditions. If you do not agree to all of these terms of use, do not use this site.</p>
+            <p>Dr. Joao Andrade and the developers make no representations as to any matter whatsoever, including accuracy, fitness for a particular purpose or non-infringement.</p>
+            <p>Dr. Joao Andrade and the developers are not liable to you or anyone else for any decision made or action taken based on reliance upon the information contained on or provided through this website. The use of the information shall be at your own risk.</p>
+        </section>
+    </main>
 
-	</div>	
-
+    <?php $this->load->view('footer'); ?>
 </body>
-<footer>
-
-	<?php $this->load->view('footer'); ?>
-
-</footer>
 </html>

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -332,3 +332,99 @@ input[type="text"]:focus, input[type="number"]:focus {
 @media (min-width: 768px) {
     .mobile-submit { display: none; }
 }
+
+/* ============================================================================
+   Results page
+   ============================================================================ */
+.results-shell { max-width: 960px; margin: 0 auto; padding: var(--space-8) var(--space-4); }
+.results-header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-4); }
+.results-header h1 { margin: 0; }
+.results-header .timestamp { color: var(--color-muted); font-size: 13px; }
+
+.toolbar {
+    position: sticky; top: var(--topbar-h); z-index: 10;
+    display: flex; flex-wrap: wrap; gap: var(--space-2);
+    padding: var(--space-3) 0;
+    background: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: var(--space-6);
+}
+.toolbar .btn { padding: 8px 14px; font-size: 13px; }
+.toolbar .btn i { font-size: 14px; }
+
+.result-card {
+    background: var(--color-surface); border: 1px solid var(--color-border);
+    border-radius: var(--radius); box-shadow: var(--shadow-sm);
+    padding: var(--space-6); margin-bottom: var(--space-4);
+}
+.result-card .card-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+.result-card h3 { margin: 0; font-size: 16px; }
+.result-card .value { font-family: var(--font-mono); font-size: 26px; font-weight: 700; color: var(--color-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+.result-card .ref-btn {
+    background: transparent; border: 0; color: var(--color-muted); cursor: pointer;
+    width: 28px; height: 28px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+}
+.result-card .ref-btn:hover { color: var(--color-primary); background: var(--color-surface-alt); }
+.result-card .interp { margin: var(--space-3) 0 0; padding-top: var(--space-3); border-top: 1px solid var(--color-border); font-size: 13px; color: var(--color-ink-2); line-height: 1.55; }
+.result-card .hamada-image { display: block; max-width: 360px; margin: var(--space-3) auto 0; border-radius: var(--radius-sm); }
+
+.empty-state { text-align: center; padding: var(--space-12) var(--space-4); color: var(--color-muted); }
+.empty-state h2 { color: var(--color-ink); }
+
+/* Toast (export.js will toggle .show) */
+.toast {
+    position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(20px);
+    background: var(--color-ink); color: #fff;
+    padding: 10px 16px; border-radius: var(--radius-sm);
+    font-size: 14px; font-weight: 500;
+    box-shadow: var(--shadow);
+    opacity: 0; pointer-events: none; z-index: 1000;
+    transition: opacity 180ms, transform 180ms;
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); pointer-events: auto; }
+.toast.success { background: var(--color-success); }
+.toast.error   { background: var(--color-danger); }
+
+/* Modal (references) — replaces Bootstrap modal */
+.modal-backdrop {
+    position: fixed; inset: 0; background: rgba(15, 23, 42, 0.5);
+    display: none; align-items: center; justify-content: center; z-index: 100;
+}
+.modal-backdrop.show { display: flex; }
+.modal-dialog {
+    background: var(--color-surface); border-radius: var(--radius-lg);
+    max-width: 720px; width: calc(100% - 32px); max-height: 85vh;
+    display: flex; flex-direction: column;
+    box-shadow: 0 20px 60px rgba(15,23,42,0.25);
+}
+.modal-head { display: flex; align-items: center; justify-content: space-between; padding: var(--space-4) var(--space-6); border-bottom: 1px solid var(--color-border); }
+.modal-head h2 { margin: 0; font-size: 18px; }
+.modal-close { background: transparent; border: 0; font-size: 22px; cursor: pointer; color: var(--color-muted); line-height: 1; }
+.modal-close:hover { color: var(--color-ink); }
+.modal-body { padding: var(--space-6); overflow-y: auto; }
+.modal-body .reference { display: none; }
+.modal-body .reference.active { display: block; }
+.modal-body .reference p { font-size: 14px; color: var(--color-ink-2); line-height: 1.6; }
+.modal-body .reference p:first-child b { color: var(--color-ink); }
+
+/* PDF template (offscreen) */
+.pdf-template {
+    position: absolute; left: -10000px; top: 0; width: 780px;
+    padding: 20px; background: #fff; color: #000;
+    font-family: var(--font-sans); font-size: 12px;
+}
+.pdf-template h1 { font-size: 20px; }
+.pdf-template h2 { font-size: 14px; margin-top: 18px; }
+.pdf-template .pdf-kv { display: grid; grid-template-columns: 200px 1fr; gap: 4px 12px; margin-bottom: 4px; font-size: 12px; }
+.pdf-template .pdf-kv span:first-child { color: #555; }
+.pdf-template .pdf-score { border-top: 1px solid #ddd; padding-top: 8px; margin-top: 6px; }
+.pdf-template .pdf-score strong { font-size: 13px; }
+.pdf-template .pdf-score .val { color: #2563eb; font-family: var(--font-mono); font-weight: 700; margin-left: 8px; }
+.pdf-template .pdf-ref { border-top: 1px solid #eee; padding-top: 6px; margin-top: 8px; font-size: 11px; color: #333; }
+.pdf-template footer { margin-top: 24px; padding-top: 12px; border-top: 2px solid #0f172a; font-size: 10px; color: #555; }
+
+@media (max-width: 640px) {
+    .toolbar .btn-label { display: none; }
+    .toolbar .btn { padding: 8px 10px; }
+}

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -178,3 +178,28 @@ input[type="text"]:focus, input[type="number"]:focus {
     max-width: 420px !important;
 }
 .tippy-box[data-theme='customTooltipCssTema'] .tippy-content { padding: 10px 12px; }
+
+/* ============================================================================
+   Home page
+   ============================================================================ */
+.home-hero {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    min-height: calc(100vh - var(--topbar-h));
+    padding: var(--space-12) var(--space-4);
+    text-align: center;
+}
+.home-hero .eyebrow {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--color-primary); margin-bottom: var(--space-4);
+}
+.home-hero h1 { font-size: 48px; margin-bottom: var(--space-4); }
+.home-hero .lead {
+    font-size: 18px; color: var(--color-muted); max-width: 520px; margin: 0 auto var(--space-8);
+}
+.home-hero .actions { display: inline-flex; gap: var(--space-3); }
+@media (max-width: 640px) {
+    .home-hero h1 { font-size: 34px; }
+    .home-hero .lead { font-size: 16px; }
+    .home-hero .actions { flex-direction: column; width: 100%; max-width: 320px; }
+    .home-hero .actions .btn { width: 100%; }
+}

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -263,8 +263,8 @@ input[type="text"]:focus, input[type="number"]:focus {
 }
 .sidebar li a.active { background: rgba(37, 99, 235, 0.08); color: var(--color-primary); }
 .sidebar li a.active .marker { border-color: var(--color-primary); background: var(--color-primary); color: #fff; }
-.sidebar li a.done .marker { border-color: var(--color-success); background: var(--color-success); color: #fff; }
-.sidebar li a.done .marker::before { content: "✓"; }
+.sidebar li a.done .marker { border-color: var(--color-success); background: var(--color-success); color: transparent; font-size: 0; }
+.sidebar li a.done .marker::before { content: "✓"; color: #fff; font-size: 11px; }
 
 .sidebar .progress { margin-top: auto; padding-top: var(--space-4); border-top: 1px solid var(--color-border); }
 .sidebar .progress-label { display: flex; justify-content: space-between; font-size: 12px; color: var(--color-muted); margin-bottom: 6px; }

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -408,22 +408,6 @@ input[type="text"]:focus, input[type="number"]:focus {
 .modal-body .reference p { font-size: 14px; color: var(--color-ink-2); line-height: 1.6; }
 .modal-body .reference p:first-child b { color: var(--color-ink); }
 
-/* PDF template (offscreen) */
-.pdf-template {
-    position: absolute; left: -10000px; top: 0; width: 780px;
-    padding: 20px; background: #fff; color: #000;
-    font-family: var(--font-sans); font-size: 12px;
-}
-.pdf-template h1 { font-size: 20px; }
-.pdf-template h2 { font-size: 14px; margin-top: 18px; }
-.pdf-template .pdf-kv { display: grid; grid-template-columns: 200px 1fr; gap: 4px 12px; margin-bottom: 4px; font-size: 12px; }
-.pdf-template .pdf-kv span:first-child { color: #555; }
-.pdf-template .pdf-score { border-top: 1px solid #ddd; padding-top: 8px; margin-top: 6px; }
-.pdf-template .pdf-score strong { font-size: 13px; }
-.pdf-template .pdf-score .val { color: #2563eb; font-family: var(--font-mono); font-weight: 700; margin-left: 8px; }
-.pdf-template .pdf-ref { border-top: 1px solid #eee; padding-top: 6px; margin-top: 8px; font-size: 11px; color: #333; }
-.pdf-template footer { margin-top: 24px; padding-top: 12px; border-top: 2px solid #0f172a; font-size: 10px; color: #555; }
-
 @media (max-width: 640px) {
     .toolbar .btn-label { display: none; }
     .toolbar .btn { padding: 8px 10px; }
@@ -435,7 +419,7 @@ input[type="text"]:focus, input[type="number"]:focus {
 @media print {
     body { background: #fff; color: #000; }
     .topbar, .toolbar, .mobile-submit, .drawer-backdrop, .modal-backdrop, .toast,
-    .sidebar, .ref-btn, .btn, .pdf-template { display: none !important; }
+    .sidebar, .ref-btn, .btn { display: none !important; }
     .results-shell { max-width: none; padding: 0; margin: 0; }
     .results-header { display: block; margin-bottom: 16px; }
     .results-header h1 { font-size: 22px; color: #000; }

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -428,3 +428,25 @@ input[type="text"]:focus, input[type="number"]:focus {
     .toolbar .btn-label { display: none; }
     .toolbar .btn { padding: 8px 10px; }
 }
+
+/* ============================================================================
+   Print
+   ============================================================================ */
+@media print {
+    body { background: #fff; color: #000; }
+    .topbar, .toolbar, .mobile-submit, .drawer-backdrop, .modal-backdrop, .toast,
+    .sidebar, .ref-btn, .btn, .pdf-template { display: none !important; }
+    .results-shell { max-width: none; padding: 0; margin: 0; }
+    .results-header { display: block; margin-bottom: 16px; }
+    .results-header h1 { font-size: 22px; color: #000; }
+    .results-header .timestamp { font-size: 11px; color: #555; }
+    .result-card {
+        border: 1px solid #ccc !important; box-shadow: none !important;
+        page-break-inside: avoid; break-inside: avoid;
+        margin-bottom: 10px; padding: 10px;
+    }
+    .result-card .card-head { gap: 12px; }
+    .result-card h3 { font-size: 13px; color: #000; }
+    .result-card .value { color: #000; font-size: 16px; }
+    .result-card .interp { font-size: 11px; color: #000; border-top: 1px solid #ccc; }
+}

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -358,8 +358,8 @@ input[type="text"]:focus, input[type="number"]:focus {
     padding: var(--space-6); margin-bottom: var(--space-4);
 }
 .result-card .card-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
-.result-card h3 { margin: 0; font-size: 16px; }
-.result-card .value { font-family: var(--font-mono); font-size: 26px; font-weight: 700; color: var(--color-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+.result-card h3 { margin: 0; font-size: 18px; line-height: 1.3; }
+.result-card .value { font-family: var(--font-mono); font-size: 22px; font-weight: 700; color: var(--color-primary); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; line-height: 1.2; }
 .result-card .ref-btn {
     background: transparent; border: 0; color: var(--color-muted); cursor: pointer;
     width: 28px; height: 28px; border-radius: 50%;

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -1,428 +1,180 @@
-* {
-	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
-body, html{
-    height: 100%;
+/* ============================================================================
+   AFibRisk — Design tokens
+   ============================================================================ */
+:root {
+    --color-ink:          #0f172a;
+    --color-ink-2:        #1e293b;
+    --color-muted:        #64748b;
+    --color-border:       #e2e8f0;
+    --color-surface:      #ffffff;
+    --color-surface-alt:  #f8fafc;
+    --color-primary:      #2563eb;
+    --color-primary-dark: #1d4ed8;
+    --color-success:      #16a34a;
+    --color-danger:       #dc2626;
+
+    --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-6: 24px;
+    --space-8: 32px;
+    --space-12: 48px;
+
+    --radius-sm: 6px;
+    --radius:    10px;
+    --radius-lg: 16px;
+
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow:    0 4px 12px rgba(15, 23, 42, 0.08);
+
+    --topbar-h: 56px;
+    --sidebar-w: 260px;
 }
 
-#background1 {
-	background-image: url("../images/bg-1.jpg");
-	background-size: 100% 100%;
-   	background-repeat: no-repeat;
-   	background-position: center center;
-   	background-attachment: fixed;
-    overflow-y: hidden;
-    overflow-x: hidden;
+/* ============================================================================
+   Reset + base
+   ============================================================================ */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+    font-family: var(--font-sans);
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--color-ink-2);
+    background: var(--color-surface-alt);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
 }
 
-#background2 {
-	background-image: url("../images/bg-2.jpg");
-	background-size: 100% 100%;
-   	background-repeat: no-repeat;
-   	background-position: center center;
-   	background-attachment: fixed;
-    overflow-y: hidden;
-    overflow-x: hidden;
+h1, h2, h3, h4 { color: var(--color-ink); font-weight: 700; margin: 0 0 var(--space-4); line-height: 1.25; }
+h1 { font-size: 32px; }
+h2 { font-size: 22px; }
+h3 { font-size: 18px; }
+p  { margin: 0 0 var(--space-4); }
+a  { color: var(--color-primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ============================================================================
+   Focus ring — accessibility baseline
+   ============================================================================ */
+:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 
-#background3 {
-	background-image: url("../images/bg-3.jpg");
-	background-size: 100% 100%;
-   	background-repeat: no-repeat;
-   	background-position: center center;
-   	background-attachment: fixed;
-    overflow-y: hidden;
-    overflow-x: hidden;
+/* ============================================================================
+   Utility
+   ============================================================================ */
+.sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+.container-narrow {
+    max-width: 720px; margin: 0 auto; padding: var(--space-8) var(--space-4);
 }
 
-.container-fluid {
-    height: 96.4vh;
+/* ============================================================================
+   Buttons
+   ============================================================================ */
+.btn {
+    display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2);
+    padding: 10px 18px; border: 1px solid transparent; border-radius: var(--radius-sm);
+    font-family: inherit; font-size: 14px; font-weight: 600;
+    cursor: pointer; text-decoration: none; transition: background 120ms, border-color 120ms;
+    background: transparent; color: var(--color-ink);
+}
+.btn:hover { text-decoration: none; }
+.btn-primary { background: var(--color-primary); color: #fff; }
+.btn-primary:hover { background: var(--color-primary-dark); color: #fff; }
+.btn-secondary { background: var(--color-surface); color: var(--color-ink); border-color: var(--color-border); }
+.btn-secondary:hover { background: var(--color-surface-alt); }
+.btn-ghost { background: transparent; color: var(--color-muted); }
+.btn-ghost:hover { color: var(--color-ink); background: var(--color-surface-alt); }
+.btn[aria-disabled="true"] { opacity: 0.5; pointer-events: none; }
+
+/* ============================================================================
+   Topbar — shared across all pages
+   ============================================================================ */
+.topbar {
+    position: sticky; top: 0; z-index: 20;
+    height: var(--topbar-h);
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 var(--space-4);
+    background: var(--color-ink); color: #e2e8f0;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.topbar .brand { display: inline-flex; align-items: center; gap: var(--space-2); font-weight: 700; color: #fff; font-size: 15px; letter-spacing: 0.01em; text-decoration: none; }
+.topbar .brand:hover { text-decoration: none; }
+.topbar .brand::before { content: ""; display: inline-block; width: 10px; height: 10px; border-radius: 50%; background: var(--color-primary); }
+.topbar nav { display: flex; gap: var(--space-2); align-items: center; }
+.topbar nav a { color: #cbd5e1; font-size: 14px; font-weight: 500; padding: 6px 10px; border-radius: var(--radius-sm); }
+.topbar nav a:hover { color: #fff; background: rgba(255,255,255,0.08); text-decoration: none; }
+.topbar .hamburger {
+    display: none; background: none; border: 0; color: #cbd5e1; font-size: 22px; cursor: pointer;
+    padding: 4px 8px; border-radius: var(--radius-sm);
+}
+.topbar .hamburger:hover { background: rgba(255,255,255,0.08); color: #fff; }
+
+/* ============================================================================
+   Forms
+   ============================================================================ */
+label { display: block; font-size: 13px; font-weight: 600; color: var(--color-ink-2); margin-bottom: 6px; }
+input[type="text"], input[type="number"] {
+    display: block; width: 100%; max-width: 220px;
+    padding: 8px 10px; font-family: inherit; font-size: 14px;
+    color: var(--color-ink); background: var(--color-surface);
+    border: 1px solid var(--color-border); border-radius: var(--radius-sm);
+    outline: none; transition: border-color 120ms, box-shadow 120ms;
+}
+input[type="text"]:focus, input[type="number"]:focus {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
 }
 
-.centralizar-botao {
-    display: flex;
-    justify-content: space-around;
-    height: 100%;
-    flex-direction: column;
-    width: 100%;
-    align-items: center
+/* Pill radios: Yes/No, alcohol, etc. */
+.pill-group { display: inline-flex; flex-wrap: wrap; gap: 8px; }
+.pill-group input[type="radio"] { position: absolute; opacity: 0; pointer-events: none; }
+.pill-group label {
+    display: inline-flex; align-items: center;
+    padding: 6px 14px; margin: 0;
+    background: var(--color-surface); color: var(--color-ink-2);
+    border: 1px solid var(--color-border); border-radius: 999px;
+    font-size: 13px; font-weight: 500; cursor: pointer;
+    transition: background 120ms, border-color 120ms, color 120ms;
 }
-.centralizar-botao .btneng {
-    margin-right: 23%;
-    padding-bottom: 5.5%;
-    z-index: 1;
+.pill-group label:hover { border-color: var(--color-muted); }
+.pill-group input[type="radio"]:checked + label {
+    background: var(--color-primary); color: #fff; border-color: var(--color-primary);
 }
-.btneng{
-    color: #fff;
-    font-size: 30px;
-    font-weight: 500;
-    width: 10%
-}
-.oval-shape {
-    display: none;
-    width: 150px;
-    height: 120px;
-    background-color: #031231;
-    border-radius: 50%;
-    transform: scaleX(2) rotate(128deg);
-    position: absolute;
-    top: 68%;
-    left: 30%;
-}
-.retangular-shape{
-    display: none;
-    width: 80%;
-    height:10%;
-    background-color: #0062c5;
-    border-radius: 15px;
-    position: absolute;
-    left: -5%;
-    box-shadow: 11px 16px 20px 1px #0b5cad69;
-    z-index: -1;
-}
-.btnabout{
-    color: #0964cb;
-    font-size: 25px;
-    font-weight: 600;
-}
-.title{
-    height: 14.5%;
-    padding-left: 55px;
-    align-items: flex-end;
-}
-.title span{
-    color: #fff;
-    font-size: 25px;
-   
+.pill-group input[type="radio"]:focus-visible + label {
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
 }
 
-.hr-personalizado{
-    width: 60% ;
-    height: 4px !important;
-    background-color: #53cc8b ;
-    color:  #53cc8b ;
-    border-radius: 10px;
-    margin: 1.5rem 0;
-}
-p{
-    color: #949494;
-    padding-left: 2px;
-}
+/* Field row (label + control inline on desktop) */
+.field { margin-bottom: var(--space-4); }
+.field .hint { font-size: 12px; color: var(--color-muted); margin-top: 4px; }
+.field-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
 
-#formquests{
-    margin-top: 5rem;
-    padding-left: 25px;
-}
+/* ============================================================================
+   Scrollbar (webkit)
+   ============================================================================ */
+::-webkit-scrollbar        { width: 10px; height: 10px; }
+::-webkit-scrollbar-track  { background: var(--color-surface-alt); }
+::-webkit-scrollbar-thumb  { background: #cbd5e1; border-radius: 999px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-muted); }
 
-#formprincipal{
-    width: 55%;
-    overflow-y: auto;
-    overflow-x: hidden;
-    height: 60vh;
-}
-
-summary {
-    padding-left: 2px;
-    color: #949494;
-    font-size: 20px;
-    font-weight: 600;
-    display: block;
-    text-decoration: underline;
-}
-
-summary a {
-    color: #949494;
-    text-decoration: none;
-    border-bottom: 2px solid #949494;
-    padding-bottom: 1px;
-    display: inline-block;
-}
-
-summary a:hover {
-    color: #949494;
-}
-
-#field_1, #field_2, #field_3, #field_4, #field_5{
-    color: #0062c5;
-}
-.custom-radio input[type="radio"] {
-    display: none;
-}
-
-/* Estilo para o span que vai mostrar os parênteses e o "X" */
-.custom-radio .radio-mark {
-    display: inline-block;
-    vertical-align: middle;
-    margin-right: 5px;
-    font-size: 18px;
-    cursor: pointer;
-}
-
-/* Quando o input está selecionado, adiciona o "X" dentro dos parênteses */
-.custom-radio input[type="radio"]:checked + .radio-mark::before {
-    content: '( ✓ ';
-    position: absolute;
-    margin-right: 0;
-    pointer-events: none;    
-    font-size: 18px;
-}
-
-.custom-radio {
-    font-size: 18px;
-    margin-right: 10px;
-    position: relative; 
-}
-
-input[type="text"] {
-    border: 1px solid #949494;
-    outline: none; 
-    width: 15%;
-    text-align: center;
-    border-radius: 3px;
-}
-
-input[type="text"]::placeholder {
-    vertical-align: bottom;
-}
-
-input[type="text"]:not(:placeholder-shown) {
-    background-image: none;
-}
-
-.card-header{
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: center
-}
-
-.container-resultado{
-    display: flex;
-    justify-content: center;
-    height: 57vh;
-    overflow-x: auto;
-    margin-top: 8rem;
-    overflow-x: hidden;
-    overflow-y: auto;
-}
-
-.subcontainer-resultado{
-    max-width: 95%;
-}
-
-.subcontainer-resultado .card-container:nth-child(odd) .card {
-    background-color: #ffffff; /* Cor de fundo para cards ímpares */
-    border: none;
-    border-radius: 0%;
-}
-
-.subcontainer-resultado .card-container:nth-child(odd) .card,
-.subcontainer-resultado .card-container:nth-child(odd) .card h5,
-.subcontainer-resultado .card-container:nth-child(odd) .card p {
-    color: #000000; /* Cor do texto para cards ímpares */
-    /* font-size: 20px; */
-}
-
-.subcontainer-resultado .card-container:nth-child(even) .card {
-    background-color: #10b1ac; /* Cor de fundo para cards pares */
-    border: none;
-    border-radius: 0%;
-}
-
-.subcontainer-resultado .card-header{
-    background-color: transparent;
-    border: none; 
-}
-
-.subcontainer-resultado .card-body p {
-    font-weight: 600;
-}
-
-.subcontainer-resultado .card-container:nth-child(even) .card,
-.subcontainer-resultado .card-container:nth-child(even) .card h5,
-.subcontainer-resultado .card-container:nth-child(even) .card p {
-    color: #ffffff; 
-}
-
-.subcontainer-resultado .card h5{
-    font-size: 25px;
-    font-weight: 800;
-}
-
-::-webkit-scrollbar {
-    width: 10px; 
-}
-
-::-webkit-scrollbar-track {
-    background: #f1f1f1;
-    border-radius: 10px; 
-}
-
-::-webkit-scrollbar-thumb {
-    background: #888; 
-    border-radius: 10px; 
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background: #555; 
-}
-
-.img-size{
-    max-width: 50%;
-    max-height: 350px;
-}
-
-.results{
-    display: none;
-}
-
-.btn-calculate{
-    background-color: #0062c5 !important;
-    width: 30% !important;
-}
-
-#sobre {
-    background-color: rgba(255, 255, 255, 0.8); /* Branco com 80% de opacidade */
-    border-radius: 10px; /* Borda arredondada */
-    margin-top: 1.5rem;
-}
-
-#sobre p{
-    color: #000000;
-}
-
+/* ============================================================================
+   Tippy tooltip theme override — matches new palette
+   ============================================================================ */
 .tippy-box[data-theme='customTooltipCssTema'] {
-    background-color: #FFFCFC;
-    color: #565151;
-    border: 1px solid #D9D9D9;
-    border-radius: 10px;
-    font-weight: 600;
-    z-index: 1000 !important;
-    font-size: 12px !important;
-    font-style: normal !important;
-    width: 50% !important;
-    max-width: 100% !important;
+    background: #0f172a; color: #f8fafc;
+    border: 1px solid #1e293b; border-radius: var(--radius-sm);
+    font-weight: 500; font-size: 13px; line-height: 1.45;
+    max-width: 420px !important;
 }
-
-.div-btn-calculate{
-    padding-right: 2rem;
-}
-
-.card-title{
-    margin-right: 5px;
-}
-
-.show-reference{
-    cursor: pointer;
-}
-
-@media (max-width: 700px) {
-
-    #background1{
-        background-size: 50%;
-        background-repeat: no-repeat;
-        background-size: cover;
-        background-position: left; 
-        margin: 0;
-        padding: 0;
-    }
-
-    #background2, #background3{
-        background-size: 100%;
-        background-repeat: no-repeat;
-        background-size: cover;
-        background-position: center;
-        margin: 0;
-        padding: 0;
-    }
-
-    .centralizar-botao {
-        justify-content: space-evenly;
-    }
-
-    .oval-shape, .retangular-shape{
-        display: block;
-    }
-
-    .centralizar-botao .btneng {
-        margin-right: 0;
-        padding-bottom: 0;
-    }
-
-    .btneng{
-        width: 100%;
-    }
-
-    .title span{
-        font-size: 40px;       
-    }
-
-    #formprincipal{
-        width: 100%;
-    }
-    .results{
-        display: flex;
-    
-    }
-
-    .container-resultado{
-        margin-top: 4rem;
-        height: 70vh;
-    }
-
-    .btn-calculate{
-        width: 100% !important;
-    }
-
-    #sobre {
-        height: 91vh;
-        overflow-y: auto;
-        overflow-x: hidden;
-    }
-
-    .img-size{
-        max-width: 100%;
-        max-height: 380px;    
-    }
-
-    .div-btn-calculate{
-        padding-right: 0rem;
-    }
-
-    
-
-}
-
-@media (min-width: 1920px) {
-    .btneng{
-        font-size: 38px;
-    }
-
-    .centralizar-botao .btneng {
-        padding-bottom: 3.5%;
-    }
-
-    .container-resultado{
-        height: 60vh;
-    }
-
-    .subcontainer-resultado{
-        max-width: 100%;
-    }
-
-    .container{
-        max-width: 1520px;
-    }
-
-    .title span{
-        font-size: 35px;       
-    }
-
-    .container-resultado{
-        margin-top: 13rem;
-    }
-
-    #sobre {
-        margin-top: 15rem;
-    }
-}
+.tippy-box[data-theme='customTooltipCssTema'] .tippy-content { padding: 10px 12px; }

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -203,3 +203,23 @@ input[type="text"]:focus, input[type="number"]:focus {
     .home-hero .actions { flex-direction: column; width: 100%; max-width: 320px; }
     .home-hero .actions .btn { width: 100%; }
 }
+
+/* ============================================================================
+   About page
+   ============================================================================ */
+.about-section { margin-bottom: var(--space-8); }
+.about-section h2 { font-size: 18px; margin-bottom: var(--space-3); }
+.about-section p  { color: var(--color-ink-2); }
+.about-credits p { margin-bottom: var(--space-1); color: var(--color-muted); font-size: 14px; }
+.about-credits p:first-child { color: var(--color-ink); font-weight: 600; font-size: 15px; }
+.disclaimer-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-danger);
+    border-radius: var(--radius);
+    padding: var(--space-6);
+    box-shadow: var(--shadow-sm);
+}
+.disclaimer-card h2 { color: var(--color-danger); text-transform: uppercase; letter-spacing: 0.05em; font-size: 13px; }
+.disclaimer-card p { font-size: 13px; color: var(--color-ink-2); margin-bottom: var(--space-3); }
+.disclaimer-card p:last-child { margin-bottom: 0; }

--- a/plataforma/assets/css/style.css
+++ b/plataforma/assets/css/style.css
@@ -223,3 +223,112 @@ input[type="text"]:focus, input[type="number"]:focus {
 .disclaimer-card h2 { color: var(--color-danger); text-transform: uppercase; letter-spacing: 0.05em; font-size: 13px; }
 .disclaimer-card p { font-size: 13px; color: var(--color-ink-2); margin-bottom: var(--space-3); }
 .disclaimer-card p:last-child { margin-bottom: 0; }
+
+/* ============================================================================
+   Questions page layout
+   ============================================================================ */
+.questions-shell {
+    display: grid;
+    grid-template-columns: var(--sidebar-w) 1fr;
+    min-height: calc(100vh - var(--topbar-h));
+}
+
+.sidebar {
+    position: sticky; top: var(--topbar-h);
+    height: calc(100vh - var(--topbar-h));
+    padding: var(--space-6) var(--space-4);
+    background: var(--color-surface);
+    border-right: 1px solid var(--color-border);
+    display: flex; flex-direction: column; gap: var(--space-4);
+    overflow-y: auto;
+}
+.sidebar h2 {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--color-muted);
+    margin-bottom: var(--space-2);
+}
+.sidebar ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.sidebar li a {
+    display: flex; align-items: center; gap: var(--space-2);
+    padding: 8px 10px; border-radius: var(--radius-sm);
+    color: var(--color-ink-2); font-size: 14px; font-weight: 500;
+    text-decoration: none;
+}
+.sidebar li a:hover { background: var(--color-surface-alt); text-decoration: none; }
+.sidebar li a .marker {
+    width: 18px; height: 18px; flex: 0 0 18px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: 1.5px solid var(--color-border); border-radius: 50%;
+    color: var(--color-muted); font-size: 11px; font-weight: 700;
+}
+.sidebar li a.active { background: rgba(37, 99, 235, 0.08); color: var(--color-primary); }
+.sidebar li a.active .marker { border-color: var(--color-primary); background: var(--color-primary); color: #fff; }
+.sidebar li a.done .marker { border-color: var(--color-success); background: var(--color-success); color: #fff; }
+.sidebar li a.done .marker::before { content: "✓"; }
+
+.sidebar .progress { margin-top: auto; padding-top: var(--space-4); border-top: 1px solid var(--color-border); }
+.sidebar .progress-label { display: flex; justify-content: space-between; font-size: 12px; color: var(--color-muted); margin-bottom: 6px; }
+.sidebar .progress-bar { height: 6px; background: var(--color-border); border-radius: 999px; overflow: hidden; }
+.sidebar .progress-fill { height: 100%; background: var(--color-primary); width: 0%; transition: width 180ms ease; }
+.sidebar .btn-calculate-wrap { margin-top: var(--space-4); }
+.sidebar .btn-calculate-wrap .btn { width: 100%; }
+
+.questions-content { padding: var(--space-8) var(--space-6); max-width: 880px; }
+.question-section { scroll-margin-top: calc(var(--topbar-h) + var(--space-4)); margin-bottom: var(--space-12); }
+.question-section h2 { font-size: 22px; }
+.question-section .section-hint { color: var(--color-muted); font-size: 14px; margin-bottom: var(--space-6); }
+.question-section .field-row { margin-bottom: var(--space-4); }
+.question-section .divider { height: 1px; background: var(--color-border); margin: var(--space-8) 0; }
+
+.section-nav { display: flex; justify-content: space-between; gap: var(--space-3); margin-top: var(--space-6); }
+.section-nav .btn[data-disabled="true"] { visibility: hidden; }
+
+.tooltip-trigger {
+    display: inline-block; margin-left: 6px;
+    width: 16px; height: 16px; line-height: 16px; text-align: center;
+    border-radius: 50%; border: 1px solid var(--color-border);
+    color: var(--color-muted); font-size: 11px; font-weight: 700;
+    cursor: help;
+}
+.tooltip-trigger:hover { color: var(--color-primary); border-color: var(--color-primary); }
+
+.drawer-backdrop { display: none; }
+
+@media (max-width: 1023px) {
+    :root { --sidebar-w: 220px; }
+    .questions-content .field-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 767px) {
+    .questions-shell { grid-template-columns: 1fr; }
+    .topbar .hamburger { display: inline-flex; }
+    .sidebar {
+        position: fixed; top: var(--topbar-h); left: 0;
+        width: 85%; max-width: 320px; height: calc(100vh - var(--topbar-h));
+        z-index: 15;
+        transform: translateX(-100%);
+        transition: transform 220ms ease;
+        border-right: 1px solid var(--color-border);
+        box-shadow: var(--shadow);
+    }
+    .sidebar.open { transform: translateX(0); }
+    .drawer-backdrop {
+        display: block; position: fixed; inset: var(--topbar-h) 0 0 0;
+        background: rgba(15, 23, 42, 0.5);
+        opacity: 0; pointer-events: none; transition: opacity 200ms;
+        z-index: 14;
+    }
+    .drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+    .questions-content { padding: var(--space-6) var(--space-4) 96px; }
+    .sidebar .btn-calculate-wrap { display: none; }
+    .mobile-submit {
+        position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
+        padding: var(--space-3) var(--space-4);
+        background: var(--color-surface);
+        border-top: 1px solid var(--color-border);
+    }
+    .mobile-submit .btn { width: 100%; }
+}
+@media (min-width: 768px) {
+    .mobile-submit { display: none; }
+}

--- a/plataforma/assets/js/export.js
+++ b/plataforma/assets/js/export.js
@@ -187,6 +187,14 @@
         return parts.join('');
     }
 
+    function makePdfOverlay() {
+        const o = document.createElement('div');
+        o.setAttribute('data-afibrisk-pdf-overlay', '');
+        o.style.cssText = 'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(248,250,252,0.96);backdrop-filter:blur(2px);font:600 15px system-ui,sans-serif;color:#0f172a;letter-spacing:0.02em';
+        o.textContent = 'Generating PDF…';
+        return o;
+    }
+
     async function doPDF() {
         if (typeof window.html2pdf === 'undefined') {
             toast('PDF failed to generate. Try Print as a workaround.', 'error');
@@ -197,6 +205,16 @@
         if (!tpl || !body) return;
 
         body.innerHTML = buildPdfBody();
+
+        // Move the template on-screen so html2canvas can render it reliably,
+        // and cover the page with a loading overlay so the user doesn't see the flash.
+        const origLeft = tpl.style.left;
+        const origTop  = tpl.style.top;
+        tpl.style.left = '0';
+        tpl.style.top  = '0';
+        const overlay = makePdfOverlay();
+        document.body.appendChild(overlay);
+
         try {
             await window.html2pdf()
                 .from(tpl)
@@ -204,7 +222,7 @@
                     filename: 'afibrisk-report-' + nowFilename() + '.pdf',
                     margin: [15, 15, 15, 15],
                     image: { type: 'jpeg', quality: 0.95 },
-                    html2canvas: { scale: 2, useCORS: true },
+                    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#ffffff' },
                     jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
                     pagebreak: { mode: ['css', 'legacy'] }
                 })
@@ -213,7 +231,10 @@
         } catch (e) {
             toast('PDF failed to generate. Try Print as a workaround.', 'error');
         } finally {
-            body.innerHTML = ''; // free memory
+            tpl.style.left = origLeft || '-10000px';
+            tpl.style.top  = origTop  || '0';
+            body.innerHTML = '';
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
         }
     }
 

--- a/plataforma/assets/js/export.js
+++ b/plataforma/assets/js/export.js
@@ -138,7 +138,85 @@
         }
     }
 
-    function doPDF() { toast('PDF export not available yet', 'error'); }
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function buildPdfBody() {
+        const parts = [];
+
+        // Header
+        parts.push('<div style="color:#64748b;font-size:11px;margin-bottom:16px">Generated on ' + escapeHtml(payload.generatedHuman) + '</div>');
+
+        // Inputs
+        const inputKeys = Object.keys(payload.inputs);
+        if (inputKeys.length) {
+            parts.push('<h2>Patient inputs</h2>');
+            inputKeys.forEach(k => {
+                const label = escapeHtml(k.replace(/^\d+_?/, '').replace(/_/g, ' '));
+                parts.push('<div class="pdf-kv"><span>' + label + '</span><span>' + escapeHtml(payload.inputs[k]) + '</span></div>');
+            });
+        }
+
+        // Scores
+        parts.push('<h2>Scores</h2>');
+        payload.scores.forEach(s => {
+            parts.push(
+                '<div class="pdf-score"><strong>' + escapeHtml(s.name) + '</strong>'
+                + '<span class="val">' + escapeHtml(s.value) + '</span>'
+                + (s.interpretation ? '<p style="margin:4px 0 0;font-size:11px;color:#333">' + escapeHtml(s.interpretation) + '</p>' : '')
+                + '</div>'
+            );
+        });
+
+        // References — reuse the DOM content from the modal
+        const modal = document.getElementById('referenceBody');
+        if (modal) {
+            parts.push('<h2>References</h2>');
+            payload.scores.forEach(s => {
+                const key = s.name.replace(/\s+/g, '');
+                const ref = modal.querySelector('.reference.' + CSS.escape(key))
+                         || (/BRAFIL/i.test(s.name) ? modal.querySelector('.reference.BRAFIL') : null);
+                if (ref) {
+                    parts.push('<div class="pdf-ref">' + ref.innerHTML + '</div>');
+                }
+            });
+        }
+
+        return parts.join('');
+    }
+
+    async function doPDF() {
+        if (typeof window.html2pdf === 'undefined') {
+            toast('PDF failed to generate. Try Print as a workaround.', 'error');
+            return;
+        }
+        const tpl = document.getElementById('pdfTemplate');
+        const body = document.getElementById('pdfBody');
+        if (!tpl || !body) return;
+
+        body.innerHTML = buildPdfBody();
+        try {
+            await window.html2pdf()
+                .from(tpl)
+                .set({
+                    filename: 'afibrisk-report-' + nowFilename() + '.pdf',
+                    margin: [15, 15, 15, 15],
+                    image: { type: 'jpeg', quality: 0.95 },
+                    html2canvas: { scale: 2, useCORS: true },
+                    jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+                    pagebreak: { mode: ['css', 'legacy'] }
+                })
+                .save();
+            toast('PDF downloaded', 'success');
+        } catch (e) {
+            toast('PDF failed to generate. Try Print as a workaround.', 'error');
+        } finally {
+            body.innerHTML = ''; // free memory
+        }
+    }
 
     // ---- Wire buttons --------------------------------------------------
     document.addEventListener('click', (e) => {

--- a/plataforma/assets/js/export.js
+++ b/plataforma/assets/js/export.js
@@ -101,7 +101,6 @@
     // ---- Print ---------------------------------------------------------
     function doPrint() { window.print(); }
 
-    // Placeholders — implemented in Task 10 (CSV) and Task 11 (PDF)
     function csvEscape(v) {
         if (v === null || v === undefined) return '';
         const s = String(v);

--- a/plataforma/assets/js/export.js
+++ b/plataforma/assets/js/export.js
@@ -1,0 +1,122 @@
+(function () {
+    'use strict';
+
+    // ---- Payload ---------------------------------------------------------
+    function pad2(n) { return String(n).padStart(2, '0'); }
+    function nowISOLocal() {
+        const d = new Date();
+        const tz = -d.getTimezoneOffset();
+        const sign = tz >= 0 ? '+' : '-';
+        const abs = Math.abs(tz);
+        return d.getFullYear() + '-' + pad2(d.getMonth()+1) + '-' + pad2(d.getDate())
+             + 'T' + pad2(d.getHours()) + ':' + pad2(d.getMinutes()) + ':' + pad2(d.getSeconds())
+             + sign + pad2(Math.floor(abs/60)) + ':' + pad2(abs%60);
+    }
+    function nowHuman() {
+        const d = new Date();
+        return d.getFullYear() + '-' + pad2(d.getMonth()+1) + '-' + pad2(d.getDate())
+             + ' ' + pad2(d.getHours()) + ':' + pad2(d.getMinutes());
+    }
+    function nowFilename() {
+        const d = new Date();
+        return d.getFullYear() + '-' + pad2(d.getMonth()+1) + '-' + pad2(d.getDate())
+             + '-' + pad2(d.getHours()) + pad2(d.getMinutes());
+    }
+
+    function readScores() {
+        const cards = document.querySelectorAll('#resultCards .result-card');
+        return Array.from(cards).map(card => ({
+            name: card.dataset.scoreName,
+            value: card.dataset.scoreValue,
+            interpretation: (card.querySelector('.interp') || {}).textContent || ''
+        }));
+    }
+
+    const payload = {
+        generatedAt: nowISOLocal(),
+        generatedHuman: nowHuman(),
+        inputs: window.AFIBRISK_INPUTS || {},
+        scores: readScores()
+    };
+
+    // Populate the "Generated on" timestamp in the header
+    const ts = document.getElementById('generatedAt');
+    if (ts) ts.textContent = 'Generated on ' + payload.generatedHuman;
+
+    // ---- Toast ----------------------------------------------------------
+    const toastEl = document.getElementById('toast');
+    let toastTimer = null;
+    function toast(msg, kind) {
+        if (!toastEl) return;
+        toastEl.textContent = msg;
+        toastEl.className = 'toast show' + (kind ? ' ' + kind : '');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => { toastEl.classList.remove('show'); }, 2200);
+    }
+
+    // ---- Copy ----------------------------------------------------------
+    function formatPlainText() {
+        const lines = [];
+        lines.push('AFibRisk — Assessment');
+        lines.push('Generated: ' + payload.generatedHuman);
+        lines.push('');
+        lines.push('Scores');
+        payload.scores.forEach(s => {
+            lines.push('- ' + s.name + ': ' + s.value);
+        });
+        const inputKeys = Object.keys(payload.inputs);
+        if (inputKeys.length) {
+            lines.push('');
+            lines.push('Inputs');
+            inputKeys.forEach(k => {
+                const label = k.replace(/^\d+_?/, '').replace(/_/g, ' ');
+                lines.push('- ' + label + ': ' + payload.inputs[k]);
+            });
+        }
+        return lines.join('\n');
+    }
+
+    async function doCopy() {
+        const text = formatPlainText();
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                toast('Copied to clipboard', 'success'); return;
+            }
+        } catch (e) { /* fall through */ }
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed'; ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            if (ok) { toast('Copied to clipboard', 'success'); return; }
+        } catch (e) { /* fall through */ }
+        toast("Couldn't copy. Try Print instead.", 'error');
+    }
+
+    // ---- Print ---------------------------------------------------------
+    function doPrint() { window.print(); }
+
+    // Placeholders — implemented in Task 10 (CSV) and Task 11 (PDF)
+    function doCSV() { toast('CSV export not available yet', 'error'); }
+    function doPDF() { toast('PDF export not available yet', 'error'); }
+
+    // ---- Wire buttons --------------------------------------------------
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-action]');
+        if (!btn) return;
+        switch (btn.dataset.action) {
+            case 'copy':  doCopy();  break;
+            case 'pdf':   doPDF();   break;
+            case 'csv':   doCSV();   break;
+            case 'print': doPrint(); break;
+        }
+    });
+
+    // Expose for future testing hooks
+    window.AFibRisk = { payload, formatPlainText, nowFilename };
+})();

--- a/plataforma/assets/js/export.js
+++ b/plataforma/assets/js/export.js
@@ -137,104 +137,128 @@
         }
     }
 
-    function escapeHtml(s) {
-        return String(s == null ? '' : s)
-            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-    }
-
-    function buildPdfBody() {
-        const parts = [];
-
-        // Header
-        parts.push('<div style="color:#64748b;font-size:11px;margin-bottom:16px">Generated on ' + escapeHtml(payload.generatedHuman) + '</div>');
-
-        // Inputs
-        const inputKeys = Object.keys(payload.inputs);
-        if (inputKeys.length) {
-            parts.push('<h2>Patient inputs</h2>');
-            inputKeys.forEach(k => {
-                const label = escapeHtml(k.replace(/^\d+_?/, '').replace(/_/g, ' '));
-                parts.push('<div class="pdf-kv"><span>' + label + '</span><span>' + escapeHtml(payload.inputs[k]) + '</span></div>');
-            });
-        }
-
-        // Scores
-        parts.push('<h2>Scores</h2>');
-        payload.scores.forEach(s => {
-            parts.push(
-                '<div class="pdf-score"><strong>' + escapeHtml(s.name) + '</strong>'
-                + '<span class="val">' + escapeHtml(s.value) + '</span>'
-                + (s.interpretation ? '<p style="margin:4px 0 0;font-size:11px;color:#333">' + escapeHtml(s.interpretation) + '</p>' : '')
-                + '</div>'
-            );
-        });
-
-        // References — reuse the DOM content from the modal
+    function refTextFor(scoreName) {
         const modal = document.getElementById('referenceBody');
-        if (modal) {
-            parts.push('<h2>References</h2>');
-            payload.scores.forEach(s => {
-                const key = s.name.replace(/\s+/g, '');
-                const ref = modal.querySelector('.reference.' + CSS.escape(key))
-                         || (/BRAFIL/i.test(s.name) ? modal.querySelector('.reference.BRAFIL') : null);
-                if (ref) {
-                    parts.push('<div class="pdf-ref">' + ref.innerHTML + '</div>');
-                }
-            });
-        }
-
-        return parts.join('');
+        if (!modal) return '';
+        const key = scoreName.replace(/\s+/g, '');
+        const ref = modal.querySelector('.reference.' + CSS.escape(key))
+                 || (/BRAFIL/i.test(scoreName) ? modal.querySelector('.reference.BRAFIL') : null);
+        if (!ref) return '';
+        return (ref.innerText || ref.textContent || '').replace(/\s+\n/g, '\n').replace(/\n\s+/g, '\n').trim();
     }
 
-    function makePdfOverlay() {
-        const o = document.createElement('div');
-        o.setAttribute('data-afibrisk-pdf-overlay', '');
-        o.style.cssText = 'position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(248,250,252,0.96);backdrop-filter:blur(2px);font:600 15px system-ui,sans-serif;color:#0f172a;letter-spacing:0.02em';
-        o.textContent = 'Generating PDF…';
-        return o;
-    }
-
-    async function doPDF() {
-        if (typeof window.html2pdf === 'undefined') {
-            toast('PDF failed to generate. Try Print as a workaround.', 'error');
+    function doPDF() {
+        const jspdfNs = window.jspdf;
+        const JsPDF = jspdfNs && jspdfNs.jsPDF;
+        if (!JsPDF) {
+            toast('PDF library failed to load. Try Print as a workaround.', 'error');
             return;
         }
-        const tpl = document.getElementById('pdfTemplate');
-        const body = document.getElementById('pdfBody');
-        if (!tpl || !body) return;
-
-        body.innerHTML = buildPdfBody();
-
-        // Move the template on-screen so html2canvas can render it reliably,
-        // and cover the page with a loading overlay so the user doesn't see the flash.
-        const origLeft = tpl.style.left;
-        const origTop  = tpl.style.top;
-        tpl.style.left = '0';
-        tpl.style.top  = '0';
-        const overlay = makePdfOverlay();
-        document.body.appendChild(overlay);
 
         try {
-            await window.html2pdf()
-                .from(tpl)
-                .set({
-                    filename: 'afibrisk-report-' + nowFilename() + '.pdf',
-                    margin: [15, 15, 15, 15],
-                    image: { type: 'jpeg', quality: 0.95 },
-                    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#ffffff' },
-                    jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-                    pagebreak: { mode: ['css', 'legacy'] }
-                })
-                .save();
+            const pdf = new JsPDF({ unit: 'mm', format: 'a4', orientation: 'portrait' });
+            const pageWidth  = pdf.internal.pageSize.getWidth();
+            const pageHeight = pdf.internal.pageSize.getHeight();
+            const margin = 15;
+            const contentWidth = pageWidth - 2 * margin;
+            let y = margin;
+
+            function ensureSpace(needed) {
+                if (y + needed > pageHeight - margin) {
+                    pdf.addPage();
+                    y = margin;
+                }
+            }
+            function writeText(text, opts) {
+                opts = opts || {};
+                const size   = opts.size   || 10;
+                const style  = opts.style  || 'normal';
+                const color  = opts.color  || [15, 23, 42];
+                const indent = opts.indent || 0;
+                const lineH  = size * 0.45;
+                pdf.setFont('helvetica', style);
+                pdf.setFontSize(size);
+                pdf.setTextColor(color[0], color[1], color[2]);
+                const lines = pdf.splitTextToSize(String(text), contentWidth - indent);
+                lines.forEach(line => {
+                    ensureSpace(lineH);
+                    pdf.text(line, margin + indent, y);
+                    y += lineH;
+                });
+            }
+            function hr() {
+                ensureSpace(4);
+                pdf.setDrawColor(226, 232, 240);
+                pdf.setLineWidth(0.2);
+                pdf.line(margin, y, pageWidth - margin, y);
+                y += 3;
+            }
+            function gap(mm) { y += mm; }
+
+            // Title block
+            writeText('AFibRisk — Assessment Report', { size: 18, style: 'bold' });
+            writeText('Generated on ' + payload.generatedHuman, { size: 9, color: [100, 116, 139] });
+            gap(4);
+            hr();
+
+            // Patient inputs
+            const inputKeys = Object.keys(payload.inputs);
+            if (inputKeys.length) {
+                writeText('Patient inputs', { size: 13, style: 'bold' });
+                gap(1);
+                inputKeys.forEach(k => {
+                    const label = k.replace(/^\d+_?/, '').replace(/_/g, ' ');
+                    writeText(label + ': ' + payload.inputs[k], { size: 10, color: [30, 41, 59] });
+                });
+                gap(3);
+                hr();
+            }
+
+            // Scores
+            writeText('Scores', { size: 13, style: 'bold' });
+            gap(1);
+            payload.scores.forEach(s => {
+                ensureSpace(10);
+                writeText(s.name + ' — ' + s.value, { size: 11, style: 'bold', color: [37, 99, 235] });
+                if (s.interpretation) {
+                    writeText(s.interpretation, { size: 9, color: [51, 65, 85], indent: 2 });
+                }
+                gap(1);
+            });
+            gap(2);
+
+            // References
+            const hasRefs = payload.scores.some(s => refTextFor(s.name));
+            if (hasRefs) {
+                hr();
+                writeText('References', { size: 13, style: 'bold' });
+                gap(1);
+                payload.scores.forEach(s => {
+                    const text = refTextFor(s.name);
+                    if (!text) return;
+                    ensureSpace(8);
+                    writeText(s.name, { size: 10, style: 'bold' });
+                    writeText(text, { size: 8, color: [71, 85, 105], indent: 2 });
+                    gap(2);
+                });
+            }
+
+            // Footer on every page
+            const pageCount = pdf.internal.getNumberOfPages();
+            pdf.setFont('helvetica', 'normal');
+            pdf.setFontSize(8);
+            pdf.setTextColor(100, 116, 139);
+            for (let i = 1; i <= pageCount; i++) {
+                pdf.setPage(i);
+                pdf.text('Not a medical device. For educational/research use only. Page ' + i + ' of ' + pageCount,
+                    pageWidth / 2, pageHeight - 8, { align: 'center' });
+            }
+
+            pdf.save('afibrisk-report-' + nowFilename() + '.pdf');
             toast('PDF downloaded', 'success');
         } catch (e) {
+            console.error('[afibrisk] PDF generation failed:', e);
             toast('PDF failed to generate. Try Print as a workaround.', 'error');
-        } finally {
-            tpl.style.left = origLeft || '-10000px';
-            tpl.style.top  = origTop  || '0';
-            body.innerHTML = '';
-            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
         }
     }
 

--- a/plataforma/assets/js/export.js
+++ b/plataforma/assets/js/export.js
@@ -102,7 +102,42 @@
     function doPrint() { window.print(); }
 
     // Placeholders — implemented in Task 10 (CSV) and Task 11 (PDF)
-    function doCSV() { toast('CSV export not available yet', 'error'); }
+    function csvEscape(v) {
+        if (v === null || v === undefined) return '';
+        const s = String(v);
+        if (/[",\r\n]/.test(s)) return '"' + s.replace(/"/g, '""') + '"';
+        return s;
+    }
+
+    function doCSV() {
+        const inputKeys = Object.keys(payload.inputs);
+        const scoreKeys = payload.scores.map(s => 'score_' + s.name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, ''));
+        const headers = ['generated_at', ...inputKeys, ...scoreKeys];
+        const row = [
+            payload.generatedAt,
+            ...inputKeys.map(k => payload.inputs[k]),
+            ...payload.scores.map(s => s.value)
+        ];
+        const csv = '\uFEFF'
+            + headers.map(csvEscape).join(',') + '\r\n'
+            + row.map(csvEscape).join(',') + '\r\n';
+
+        try {
+            const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'afibrisk-' + nowFilename() + '.csv';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+            toast('CSV downloaded', 'success');
+        } catch (e) {
+            toast("Couldn't export CSV", 'error');
+        }
+    }
+
     function doPDF() { toast('PDF export not available yet', 'error'); }
 
     // ---- Wire buttons --------------------------------------------------


### PR DESCRIPTION
## Summary
- Full design refresh: new token-based CSS, rewritten landing, about, questions (sidebar + scroll-spy + progress), and results pages
- Copy / PDF / CSV / Print export from the results page, with references embedded
- PDF now built programmatically with **jsPDF** (previously html2pdf → html2canvas produced blank 300-byte PDFs because the canvas clone lost its height)

## Highlights
- Replaced Bootstrap with Inter typography and a design-token foundation
- Questionnaire: sidebar nav, scroll-spy, conditional fields, mobile drawer, progress bar
- Results: card grid, reference modal, toolbar with Copy / PDF / CSV / Print
- Print CSS + security/a11y polish
- PDF export rewritten to jsPDF 3.0.3: selectable text, ~15–30 KB output, native pagination, per-page footer

## Test plan
- [ ] Landing, About, Questions, Results pages render correctly on desktop and mobile
- [ ] Questionnaire: sidebar scroll-spy, drawer on mobile, conditional fields, progress bar
- [ ] Results: cards render, reference modal opens/closes, tooltips work
- [ ] Copy button puts plain-text report on clipboard
- [ ] CSV downloads with UTF-8 BOM and correct columns
- [ ] Print preview hides chrome and prints cards cleanly
- [ ] PDF downloads, opens non-blank, text is selectable, paginates correctly, footer on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)